### PR TITLE
Add dark mode toggle

### DIFF
--- a/AdminPanel.tsx
+++ b/AdminPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Users, UserPlus, Edit, Trash2, Shield, ShieldCheck, Music, Mail, ToggleLeft as Toggle, Save, X } from 'lucide-react';
+import { Users, UserPlus, Edit, Shield, ShieldCheck, Music, Mail, ToggleLeft as Toggle, Save, X } from 'lucide-react';
 import { useApp } from './AppContext';
 import { User } from '../types';
 

--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { AppProvider, useApp } from './AppContext';
 import { LoginForm } from './LoginForm';
 import { Navigation } from './Navigation';
@@ -11,7 +11,16 @@ import { BackToTop } from './BackToTop';
 
 function AppContent() {
   const { state } = useApp();
-  const { currentUser, currentTab } = state;
+  const { currentUser, currentTab, isDarkMode } = state;
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isDarkMode) {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [isDarkMode]);
 
   if (!currentUser) {
     return <LoginForm />;
@@ -35,7 +44,7 @@ function AppContent() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 dark:text-gray-100">
       <Navigation />
       <main className="pb-20 md:pb-0">
         <React.Suspense fallback={<div className="p-4">Chargement...</div>}>

--- a/AppContext.tsx
+++ b/AppContext.tsx
@@ -13,7 +13,8 @@ type AppAction =
   | { type: 'ADD_CONTACT'; payload: Contact }
   | { type: 'UPDATE_CONTACT'; payload: Contact }
   | { type: 'DELETE_CONTACT'; payload: string }
-  | { type: 'UPDATE_USER'; payload: User };
+  | { type: 'UPDATE_USER'; payload: User }
+  | { type: 'TOGGLE_DARK_MODE' };
 
 // Mock data
 const mockUsers: User[] = [
@@ -87,7 +88,8 @@ const initialState: AppState = {
   availabilities: mockAvailabilities,
   concerts: mockConcerts,
   contacts: mockContacts,
-  currentTab: 'dashboard'
+  currentTab: 'dashboard',
+  isDarkMode: false
 };
 
 const AppContext = createContext<{
@@ -155,6 +157,11 @@ function appReducer(state: AppState, action: AppAction): AppState {
         users: state.users.map(u =>
           u.id === action.payload.id ? action.payload : u
         )
+      };
+    case 'TOGGLE_DARK_MODE':
+      return {
+        ...state,
+        isDarkMode: !state.isDarkMode
       };
     default:
       return state;

--- a/AvailabilityCalendar.tsx
+++ b/AvailabilityCalendar.tsx
@@ -1,13 +1,11 @@
 import React, { useState } from 'react';
-import { Calendar, Check, X, Plus, Users } from 'lucide-react';
+import { Check, X, Plus, Users } from 'lucide-react';
 import { useApp } from './AppContext';
 
 export function AvailabilityCalendar() {
   const { state, dispatch } = useApp();
   const { availabilities, users, currentUser } = state;
   const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split('T')[0]);
-  const [selectedTimeSlot, setSelectedTimeSlot] = useState('19:00-22:00');
-  const [showAddModal, setShowAddModal] = useState(false);
 
   const timeSlots = [
     '14:00-17:00',

--- a/ConcertManagement.tsx
+++ b/ConcertManagement.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Plus, Music, Calendar, MapPin, Edit, Trash2, Eye } from 'lucide-react';
+import { Plus, Calendar, MapPin, Edit, Trash2, Eye } from 'lucide-react';
 import { useApp } from './AppContext';
 import { Concert } from '../types';
 

--- a/ContactDirectory.tsx
+++ b/ContactDirectory.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Plus, Search, Mail, Phone, MapPin, Edit, Trash2, Filter } from 'lucide-react';
+import { Plus, Search, Mail, Phone, MapPin, Edit, Trash2 } from 'lucide-react';
 import { useApp } from './AppContext';
 import { Contact } from '../types';
 

--- a/Navigation.tsx
+++ b/Navigation.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
-import { 
-  Home, 
-  Calendar, 
-  Mic, 
-  Users, 
-  Settings, 
+import {
+  Home,
+  Calendar,
+  Mic,
+  Users,
+  Settings,
   LogOut,
-  Music
+  Music,
+  Moon,
+  Sun
 } from 'lucide-react';
 import { useApp } from './AppContext';
 
 export function Navigation() {
   const { state, dispatch } = useApp();
-  const { currentTab, currentUser } = state;
+  const { currentTab, currentUser, isDarkMode } = state;
 
   const tabs = [
     { id: 'dashboard' as const, label: 'Tableau de bord', icon: Home },
@@ -29,11 +31,11 @@ export function Navigation() {
   return (
     <>
       {/* Desktop Navigation */}
-      <nav className="hidden md:flex bg-white border-b border-gray-200 px-6 py-4">
+      <nav className="hidden md:flex bg-white border-b border-gray-200 px-6 py-4 dark:bg-gray-800 dark:border-gray-700">
         <div className="flex items-center space-x-8">
           <div className="flex items-center space-x-2">
             <Music className="w-8 h-8 text-primary" />
-            <span className="text-2xl font-bold text-gray-800">CalZik</span>
+            <span className="text-2xl font-bold text-gray-800 dark:text-gray-100">CalZik</span>
           </div>
           
           <div className="flex space-x-1">
@@ -46,7 +48,7 @@ export function Navigation() {
                   className={`flex items-center space-x-2 px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-accent ${
                     currentTab === tab.id
                       ? 'bg-primary text-white shadow-lg'
-                      : 'text-gray-600 hover:bg-gray-100'
+                      : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700'
                   }`}
                 >
                   <Icon className="w-5 h-5" />
@@ -59,21 +61,28 @@ export function Navigation() {
 
         <div className="ml-auto flex items-center space-x-4">
           <div className="text-right">
-            <p className="text-sm font-medium text-gray-800">{currentUser?.name}</p>
-            <p className="text-xs text-gray-500">{currentUser?.instrument}</p>
+            <p className="text-sm font-medium text-gray-800 dark:text-gray-100">{currentUser?.name}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">{currentUser?.instrument}</p>
           </div>
           <button
+            onClick={() => dispatch({ type: 'TOGGLE_DARK_MODE' })}
+            className="p-2 text-gray-500 hover:text-primary hover:bg-primary/10 rounded-lg transition-all focus:outline-none focus:ring-2 focus:ring-accent dark:text-gray-400"
+            aria-label="Mode sombre"
+          >
+            {isDarkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+          </button>
+          <button
             onClick={handleLogout}
-            className="p-2 text-gray-500 hover:text-primary hover:bg-primary/10 rounded-lg transition-all focus:outline-none focus:ring-2 focus:ring-accent"
+            className="p-2 text-gray-500 hover:text-primary hover:bg-primary/10 rounded-lg transition-all focus:outline-none focus:ring-2 focus:ring-accent dark:text-gray-400"
             aria-label="Déconnexion"
-            >
+          >
             <LogOut className="w-5 h-5" />
           </button>
         </div>
       </nav>
 
       {/* Mobile Navigation */}
-      <nav className="md:hidden bg-white border-t border-gray-200 px-4 py-2 fixed bottom-0 left-0 right-0 z-10">
+      <nav className="md:hidden bg-white border-t border-gray-200 px-4 py-2 fixed bottom-0 left-0 right-0 z-10 dark:bg-gray-800 dark:border-gray-700">
         <div className="flex justify-around">
           {tabs.map((tab) => {
             const Icon = tab.icon;
@@ -84,7 +93,7 @@ export function Navigation() {
                 className={`flex flex-col items-center space-y-1 p-2 rounded-lg transition-all focus:outline-none focus:ring-2 focus:ring-accent ${
                   currentTab === tab.id
                     ? 'text-primary'
-                    : 'text-gray-500'
+                    : 'text-gray-500 dark:text-gray-400'
                 }`}
                 aria-label={tab.label}
               >
@@ -97,18 +106,27 @@ export function Navigation() {
       </nav>
 
       {/* Mobile Header */}
-      <header className="md:hidden bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between">
+      <header className="md:hidden bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between dark:bg-gray-800 dark:border-gray-700">
         <div className="flex items-center space-x-2">
           <Music className="w-6 h-6 text-primary" />
-          <span className="text-xl font-bold text-gray-800">CalZik</span>
+          <span className="text-xl font-bold text-gray-800 dark:text-gray-100">CalZik</span>
         </div>
-        <button
-          onClick={handleLogout}
-          className="p-2 text-gray-500 hover:text-primary rounded-lg focus:outline-none focus:ring-2 focus:ring-accent"
-          aria-label="Déconnexion"
-        >
-          <LogOut className="w-5 h-5" />
-        </button>
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={() => dispatch({ type: 'TOGGLE_DARK_MODE' })}
+            className="p-2 text-gray-500 hover:text-primary rounded-lg focus:outline-none focus:ring-2 focus:ring-accent dark:text-gray-400"
+            aria-label="Mode sombre"
+          >
+            {isDarkMode ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+          </button>
+          <button
+            onClick={handleLogout}
+            className="p-2 text-gray-500 hover:text-primary rounded-lg focus:outline-none focus:ring-2 focus:ring-accent dark:text-gray-400"
+            aria-label="Déconnexion"
+          >
+            <LogOut className="w-5 h-5" />
+          </button>
+        </div>
       </header>
     </>
   );

--- a/index.ts
+++ b/index.ts
@@ -47,4 +47,5 @@ export interface AppState {
   concerts: Concert[];
   contacts: Contact[];
   currentTab: 'dashboard' | 'availability' | 'concerts' | 'contacts' | 'admin';
+  isDarkMode: boolean;
 }


### PR DESCRIPTION
## Summary
- expand `AppState` with `isDarkMode`
- support dark mode in context and reducer
- toggle `dark` class via `useEffect` in `App`
- style `Navigation` for dark mode and add toggle buttons
- clean up unused imports to pass lint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68549c5f74ec8326922f7055eacfcb7b