### PR TITLE
Add calendar page and date-specific slots

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import { LoginForm } from './LoginForm';
 import { Navigation } from './Navigation';
 import { Dashboard } from './Dashboard';
 import { AvailabilityCalendar } from './AvailabilityCalendar';
+const CalendarPage = React.lazy(() => import('./CalendarPage').then(m => ({ default: m.CalendarPage }))); 
 const ConcertManagement = React.lazy(() => import('./ConcertManagement').then(m => ({ default: m.ConcertManagement })));
 const ContactDirectory = React.lazy(() => import('./ContactDirectory').then(m => ({ default: m.ContactDirectory })));
 const AdminPanel = React.lazy(() => import('./AdminPanel').then(m => ({ default: m.AdminPanel })));
@@ -32,6 +33,8 @@ function AppContent() {
         return <Dashboard />;
       case 'availability':
         return <AvailabilityCalendar />;
+      case 'calendar':
+        return <CalendarPage />;
       case 'concerts':
         return <ConcertManagement />;
       case 'contacts':

--- a/AvailabilityCalendar.tsx
+++ b/AvailabilityCalendar.tsx
@@ -26,6 +26,10 @@ export function AvailabilityCalendar() {
   const [editingSlotIndex, setEditingSlotIndex] = useState<number | null>(null);
   const [slotForm, setSlotForm] = useState({ start: '', end: '' });
 
+  const [dateSlots, setDateSlots] = useState<Record<string, { start: string; end: string }[]>>({});
+  const [editingDate, setEditingDate] = useState<string | null>(null);
+  const [dateSlotForm, setDateSlotForm] = useState<{ start: string; end: string; index: number }>({ start: '', end: '', index: -1 });
+
   const getNext30Days = () => {
     const days = [];
     const today = new Date();
@@ -81,6 +85,23 @@ export function AvailabilityCalendar() {
     return availabilities.find(
       a => a.userId === currentUser.id && a.date === date && a.timeSlot === timeSlot
     );
+  };
+
+  const handleSaveDateSlot = () => {
+    if (!editingDate) return;
+    const slots = dateSlots[editingDate] || [];
+    if (dateSlotForm.index === -1) {
+      setDateSlots({
+        ...dateSlots,
+        [editingDate]: [...slots, { start: dateSlotForm.start, end: dateSlotForm.end }]
+      });
+    } else {
+      const updated = [...slots];
+      updated[dateSlotForm.index] = { start: dateSlotForm.start, end: dateSlotForm.end };
+      setDateSlots({ ...dateSlots, [editingDate]: updated });
+    }
+    setEditingDate(null);
+    setDateSlotForm({ start: '', end: '', index: -1 });
   };
 
   const handleSaveAvailability = (e: React.FormEvent) => {
@@ -180,6 +201,93 @@ export function AvailabilityCalendar() {
           ))}
         </div>
       )}
+
+      <div className="bg-white rounded-xl shadow-md border border-gray-100 mb-6">
+        <table className="w-full">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-4 py-2 text-left text-sm font-medium text-gray-600">Date</th>
+              <th className="px-4 py-2 text-sm font-medium text-gray-600">Créneaux</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {days.map(date => (
+              <React.Fragment key={date}>
+                <tr>
+                  <td className="px-4 py-2 text-sm font-medium text-dark">
+                    {new Date(date).toLocaleDateString('fr-FR', { day: 'numeric', month: 'long' })}
+                  </td>
+                  <td className="px-4 py-2">
+                    <button
+                      onClick={() => {
+                        setEditingDate(date);
+                        setDateSlotForm({ start: '', end: '', index: -1 });
+                      }}
+                      className="flex items-center space-x-1 text-primary text-sm"
+                    >
+                      <Plus className="w-4 h-4" />
+                      <span>Ajouter créneau</span>
+                    </button>
+                  </td>
+                </tr>
+                {dateSlots[date]?.map((slot, idx) => (
+                  <tr key={idx} className="bg-gray-50">
+                    <td className="px-4 py-1" />
+                    <td className="px-4 py-1 flex justify-between items-center text-sm">
+                      <span>{slot.start} – {slot.end}</span>
+                      <span className="flex space-x-1">
+                        <button
+                          onClick={() => {
+                            setEditingDate(date);
+                            setDateSlotForm({ start: slot.start, end: slot.end, index: idx });
+                          }}
+                          className="p-1 text-gray-500 hover:text-primary"
+                          title="Modifier"
+                        >
+                          <Edit className="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => {
+                            const updated = (dateSlots[date] || []).filter((_, i) => i !== idx);
+                            setDateSlots({ ...dateSlots, [date]: updated });
+                          }}
+                          className="p-1 text-gray-500 hover:text-primary"
+                          title="Supprimer"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+                {editingDate === date && (
+                  <tr className="bg-gray-50">
+                    <td className="px-4 py-2" />
+                    <td className="px-4 py-2">
+                      <div className="flex items-center space-x-2">
+                        <input
+                          type="time"
+                          value={dateSlotForm.start}
+                          onChange={(e) => setDateSlotForm({ ...dateSlotForm, start: e.target.value })}
+                          className="border border-gray-300 rounded px-2 py-1 w-24"
+                        />
+                        <input
+                          type="time"
+                          value={dateSlotForm.end}
+                          onChange={(e) => setDateSlotForm({ ...dateSlotForm, end: e.target.value })}
+                          className="border border-gray-300 rounded px-2 py-1 w-24"
+                        />
+                        <button onClick={handleSaveDateSlot} className="text-primary text-sm">OK</button>
+                        <button onClick={() => setEditingDate(null)} className="text-xs text-gray-500">Annuler</button>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      </div>
 
       {/* Legend */}
       <div className="bg-white rounded-xl p-6 shadow-md border border-gray-100 mb-6">

--- a/CalendarPage.tsx
+++ b/CalendarPage.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import { EventApi } from '@fullcalendar/core';
+import { events } from './data/events';
+
+export function CalendarPage() {
+  const [selected, setSelected] = useState<EventApi | null>(null);
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <h1 className="text-3xl font-bold text-dark mb-6">Calendrier</h1>
+      <FullCalendar
+        plugins={[dayGridPlugin]}
+        initialView="dayGridMonth"
+        locale="fr"
+        events={events.map(e => ({
+          title: e.title,
+          date: e.date,
+          backgroundColor: e.type === 'rehearsal' ? '#bfdbfe' : '#c4b5fd',
+          borderColor: e.type === 'rehearsal' ? '#bfdbfe' : '#c4b5fd',
+          extendedProps: { location: e.location, type: e.type }
+        }))}
+        eventClick={(info) => setSelected(info.event)}
+        height="auto"
+      />
+      {selected && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-xl p-6 w-full max-w-sm">
+            <h2 className="text-xl font-bold text-dark mb-2">{selected.title}</h2>
+            <p className="text-sm mb-2">{selected.extendedProps.location}</p>
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(selected.extendedProps.location)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary text-sm underline"
+            >
+              Voir sur Google Maps
+            </a>
+            <button
+              className="block mt-2 text-primary text-sm underline"
+              onClick={() => {}}
+            >
+              Voir tous les membres dispo
+            </button>
+            <div className="mt-4 text-right">
+              <button
+                onClick={() => setSelected(null)}
+                className="bg-primary text-white px-4 py-2 rounded-lg"
+              >
+                Fermer
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Navigation.tsx
+++ b/Navigation.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Home,
   Calendar,
+  CalendarDays,
   Mic,
   Users,
   Settings,
@@ -19,6 +20,7 @@ export function Navigation() {
   const tabs = [
     { id: 'dashboard' as const, label: 'Tableau de bord', icon: Home },
     { id: 'availability' as const, label: 'Disponibilités', icon: Calendar },
+    { id: 'calendar' as const, label: 'Calendrier', icon: CalendarDays },
     { id: 'concerts' as const, label: 'Concerts', icon: Mic },
     { id: 'contacts' as const, label: 'Contacts', icon: Users },
     ...(currentUser?.role === 'admin' ? [{ id: 'admin' as const, label: 'Administration', icon: Settings }] : []),

--- a/data/events.ts
+++ b/data/events.ts
@@ -1,0 +1,11 @@
+export interface CalendarEvent {
+  date: string;
+  type: 'rehearsal' | 'gig';
+  title: string;
+  location: string;
+}
+
+export const events: CalendarEvent[] = [
+  { date: '2024-06-21', type: 'rehearsal', title: 'Répétition générale', location: 'Local de répétition' },
+  { date: '2024-06-28', type: 'gig', title: 'Concert d\'été', location: 'Salle des Fêtes' },
+];

--- a/index.ts
+++ b/index.ts
@@ -46,6 +46,6 @@ export interface AppState {
   availabilities: Availability[];
   concerts: Concert[];
   contacts: Contact[];
-  currentTab: 'dashboard' | 'availability' | 'concerts' | 'contacts' | 'admin';
+  currentTab: 'dashboard' | 'availability' | 'calendar' | 'concerts' | 'contacts' | 'admin';
   isDarkMode: boolean;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "calzik",
       "version": "0.0.0",
       "dependencies": {
+        "@fullcalendar/core": "^6.1.17",
+        "@fullcalendar/daygrid": "^6.1.17",
+        "@fullcalendar/react": "^6.1.17",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -835,6 +838,35 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.17.tgz",
+      "integrity": "sha512-0W7lnIrv18ruJ5zeWBeNZXO8qCWlzxDdp9COFEsZnyNjiEhUVnrW/dPbjRKYpL0edGG0/Lhs0ghp1z/5ekt8ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.17.tgz",
+      "integrity": "sha512-K7m+pd7oVJ9fW4h7CLDdDGJbc9szJ1xDU1DZ2ag+7oOo1aCNLv44CehzkkknM6r8EYlOOhgaelxQpKAI4glj7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.17.tgz",
+      "integrity": "sha512-AA8soHhlfRH5dUeqHnfAtzDiXa2vrgWocJSK/F5qzw/pOxc9MqpuoS/nQBROWtHHg6yQUg3DoGqOOhi7dmylXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17",
+        "react": "^16.7.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3209,6 +3241,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.17",
+    "@fullcalendar/daygrid": "^6.1.17",
+    "@fullcalendar/react": "^6.1.17",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
## Summary
- track time slots per date on Availability page
- implement Calendar view with FullCalendar
- add static event data
- wire new Calendar tab
- include FullCalendar deps

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854a73049088326a73e79a194c340ed