### PR TITLE
Add member availability confirmations and calendar link

### DIFF
--- a/CalendarPage.tsx
+++ b/CalendarPage.tsx
@@ -3,8 +3,10 @@ import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import { EventApi } from '@fullcalendar/core';
 import { events } from './data/events';
+import { useApp } from './AppContext';
 
 export function CalendarPage() {
+  const { dispatch } = useApp();
   const [selected, setSelected] = useState<EventApi | null>(null);
 
   return (
@@ -15,11 +17,12 @@ export function CalendarPage() {
         initialView="dayGridMonth"
         locale="fr"
         events={events.map(e => ({
+          id: e.id,
           title: e.title,
           date: e.date,
-          backgroundColor: e.type === 'rehearsal' ? '#bfdbfe' : '#c4b5fd',
-          borderColor: e.type === 'rehearsal' ? '#bfdbfe' : '#c4b5fd',
-          extendedProps: { location: e.location, type: e.type }
+          backgroundColor: e.type === 'rehearsal' ? '#60A5FA' : '#A78BFA',
+          borderColor: e.type === 'rehearsal' ? '#60A5FA' : '#A78BFA',
+          extendedProps: { venue: e.venue, type: e.type }
         }))}
         eventClick={(info) => setSelected(info.event)}
         height="auto"
@@ -28,9 +31,9 @@ export function CalendarPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
           <div className="bg-white rounded-xl p-6 w-full max-w-sm">
             <h2 className="text-xl font-bold text-dark mb-2">{selected.title}</h2>
-            <p className="text-sm mb-2">{selected.extendedProps.location}</p>
+            <p className="text-sm mb-2">{selected.extendedProps.venue}</p>
             <a
-              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(selected.extendedProps.location)}`}
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(selected.extendedProps.venue)}`}
               target="_blank"
               rel="noopener noreferrer"
               className="text-primary text-sm underline"
@@ -39,9 +42,19 @@ export function CalendarPage() {
             </a>
             <button
               className="block mt-2 text-primary text-sm underline"
-              onClick={() => {}}
+              onClick={() => {
+                if (selected) {
+                  const date = selected.startStr;
+                  setSelected(null);
+                  dispatch({ type: 'SET_TAB', payload: 'availability' });
+                  setTimeout(() => {
+                    const el = document.getElementById(`avail-${date}`);
+                    el?.scrollIntoView({ behavior: 'smooth' });
+                  }, 100);
+                }
+              }}
             >
-              Voir tous les membres dispo
+              Voir disponibilités
             </button>
             <div className="mt-4 text-right">
               <button

--- a/MemberAvailabilityRow.tsx
+++ b/MemberAvailabilityRow.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { User } from './index';
+
+export interface ConfirmationsState {
+  [date: string]: {
+    [slotId: string]: {
+      [memberId: string]: boolean;
+    };
+  };
+}
+
+interface Props {
+  members: User[];
+  date: string;
+  slotId: string;
+  confirmations: ConfirmationsState;
+  setConfirmations: React.Dispatch<React.SetStateAction<ConfirmationsState>>;
+}
+
+export function MemberAvailabilityRow({ members, date, slotId, confirmations, setConfirmations }: Props) {
+  const toggle = (memberId: string) => {
+    setConfirmations(prev => {
+      const dateConf = prev[date] || {};
+      const slotConf = dateConf[slotId] || {};
+      const current = slotConf[memberId] || false;
+      return {
+        ...prev,
+        [date]: {
+          ...dateConf,
+          [slotId]: {
+            ...slotConf,
+            [memberId]: !current
+          }
+        }
+      };
+    });
+  };
+
+  const slotConf = confirmations[date]?.[slotId] || {};
+  const availableCount = members.filter(m => slotConf[m.id]).length;
+
+  return (
+    <div className="space-y-1">
+      {members.map(m => {
+        const available = slotConf[m.id] ?? false;
+        return (
+          <div key={m.id} className="flex items-center justify-between text-sm">
+            <span>{m.name}</span>
+            <button
+              onClick={() => toggle(m.id)}
+              className={`text-white px-2 py-1 rounded ${available ? 'bg-green-500' : 'bg-red-500'}`}
+            >
+              {available ? '✅' : '❌'}
+            </button>
+          </div>
+        );
+      })}
+      <div className="text-xs text-gray-500 mt-1">
+        {availableCount}/{members.length} disponibles
+      </div>
+    </div>
+  );
+}

--- a/data/events.ts
+++ b/data/events.ts
@@ -1,11 +1,12 @@
 export interface CalendarEvent {
+  id: string;
+  title: string;
   date: string;
   type: 'rehearsal' | 'gig';
-  title: string;
-  location: string;
+  venue: string;
 }
 
 export const events: CalendarEvent[] = [
-  { date: '2024-06-21', type: 'rehearsal', title: 'Répétition générale', location: 'Local de répétition' },
-  { date: '2024-06-28', type: 'gig', title: 'Concert d\'été', location: 'Salle des Fêtes' },
+  { id: '1', title: 'Répétition générale', date: '2024-06-21', type: 'rehearsal', venue: 'Local de répétition' },
+  { id: '2', title: "Concert d'été", date: '2024-06-28', type: 'gig', venue: 'Salle des Fêtes' },
 ];


### PR DESCRIPTION
## Summary
- add `MemberAvailabilityRow` component for per-member confirmations
- track confirmations state in `AvailabilityCalendar`
- show availability toggle rows with counters
- update calendar events data structure and styling
- link from calendar events to availability section

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854aaf4de9c832692c9f28490faaf27