### PR TITLE
Integrate custom slots into availability calendar

### DIFF
--- a/data/events.ts
+++ b/data/events.ts
@@ -8,5 +8,6 @@ export interface CalendarEvent {
 
 export const events: CalendarEvent[] = [
   { id: '1', title: 'Répétition générale', date: '2024-06-21', type: 'rehearsal', venue: 'Local de répétition' },
-  { id: '2', title: "Concert d'été", date: '2024-06-28', type: 'gig', venue: 'Salle des Fêtes' },
+  { id: '2', title: 'Concert au parc', date: '2024-06-22', type: 'gig', venue: 'Parc Central' },
+  { id: '3', title: "Concert d'été", date: '2024-06-28', type: 'gig', venue: 'Salle des Fêtes' },
 ];


### PR DESCRIPTION
## Summary
- embed custom slots directly in the main availability grid
- remove the separate "Ajouter créneau" table
- update event list with an extra concert on 22/06

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6854ad116d508326a809f4d90b19f881