### PR TITLE
Add new tabs and simplify availability view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,8 @@ const CalendarPage = React.lazy(() => import('./CalendarPage').then(m => ({ defa
 const ConcertManagement = React.lazy(() => import('./ConcertManagement').then(m => ({ default: m.ConcertManagement })));
 const ContactDirectory = React.lazy(() => import('./ContactDirectory').then(m => ({ default: m.ContactDirectory })));
 const AdminPanel = React.lazy(() => import('./AdminPanel').then(m => ({ default: m.AdminPanel })));
+const IdeaBoardPage = React.lazy(() => import('./IdeaBoardPage').then(m => ({ default: m.IdeaBoardPage })));
+const DocumentsPage = React.lazy(() => import('./DocumentsPage').then(m => ({ default: m.DocumentsPage })));
 import { BackToTop } from './BackToTop';
 
 function AppContent() {
@@ -39,6 +41,10 @@ function AppContent() {
         return <ConcertManagement />;
       case 'contacts':
         return <ContactDirectory />;
+      case 'ideas':
+        return <IdeaBoardPage />;
+      case 'documents':
+        return <DocumentsPage />;
       case 'admin':
         return currentUser.role === 'admin' ? <AdminPanel /> : <Dashboard />;
       default:

--- a/AvailabilityCalendar.tsx
+++ b/AvailabilityCalendar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Check, X, Plus, Users, Edit, Trash2 } from 'lucide-react';
+import { Plus, Users, Edit, Trash2 } from 'lucide-react';
 import { useApp } from './AppContext';
 import { Availability } from '../types';
 import { MemberAvailabilityRow, ConfirmationsState } from './MemberAvailabilityRow';
@@ -18,14 +18,6 @@ export function AvailabilityCalendar() {
     end: ''
   });
 
-  const [timeSlots, setTimeSlots] = useState<string[]>([
-    '14:00-17:00',
-    '17:00-20:00',
-    '19:00-22:00',
-    '20:00-23:00'
-  ]);
-  const [editingSlotIndex, setEditingSlotIndex] = useState<number | null>(null);
-  const [slotForm, setSlotForm] = useState({ start: '', end: '' });
 
   const [dateSlots, setDateSlots] = useState<Record<string, { start: string; end: string }[]>>({});
   const [editingDate, setEditingDate] = useState<string | null>(null);
@@ -44,51 +36,6 @@ export function AvailabilityCalendar() {
     return days;
   };
 
-  const getAvailabilityForSlot = (date: string, timeSlot: string) => {
-    return availabilities.filter(a => a.date === date && a.timeSlot === timeSlot);
-  };
-
-  const getAvailabilityColor = (available: number, total: number) => {
-    const percentage = total > 0 ? available / total : 0;
-    if (percentage === 1) return 'bg-success';
-    if (percentage >= 0.8) return 'bg-accent';
-    if (percentage >= 0.5) return 'bg-accent/80';
-    if (percentage > 0) return 'bg-accent/60';
-    return 'bg-primary';
-  };
-
-  const handleToggleAvailability = (date: string, timeSlot: string) => {
-    if (!currentUser) return;
-
-    const existing = availabilities.find(
-      a => a.userId === currentUser.id && a.date === date && a.timeSlot === timeSlot
-    );
-
-    if (existing) {
-      dispatch({
-        type: 'UPDATE_AVAILABILITY',
-        payload: { ...existing, isAvailable: !existing.isAvailable }
-      });
-    } else {
-      dispatch({
-        type: 'ADD_AVAILABILITY',
-        payload: {
-          id: Math.random().toString(36).substr(2, 9),
-          userId: currentUser.id,
-          date,
-          timeSlot,
-          isAvailable: true
-        }
-      });
-    }
-  };
-
-  const getUserAvailability = (date: string, timeSlot: string) => {
-    if (!currentUser) return null;
-    return availabilities.find(
-      a => a.userId === currentUser.id && a.date === date && a.timeSlot === timeSlot
-    );
-  };
 
   const handleSaveDateSlot = () => {
     if (!editingDate) return;
@@ -151,17 +98,6 @@ export function AvailabilityCalendar() {
             Gérez vos disponibilités et consultez celles du groupe
           </p>
         </div>
-        <button
-          onClick={() => {
-            setEditingAvailability(null);
-            setAvailabilityForm({ date: selectedDate, start: '', end: '' });
-            setShowModal(true);
-          }}
-          className="bg-primary text-white px-4 py-2 rounded-lg font-medium hover:bg-primary/90 transition-colors flex items-center space-x-2 focus:outline-none focus:ring-2 focus:ring-accent"
-        >
-          <Plus className="w-5 h-5" />
-          <span>Ajouter disponibilité</span>
-        </button>
       </div>
 
       {userSlots.length > 0 && (
@@ -237,48 +173,7 @@ export function AvailabilityCalendar() {
       {/* Calendar Grid */}
       <div className="bg-white rounded-xl shadow-md border border-gray-100 overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[800px]">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-4 py-3 text-left text-sm font-medium text-gray-600">Date</th>
-                {timeSlots.map((slot, idx) => (
-                  <th key={slot} className="px-4 py-3 text-center text-sm font-medium text-gray-600 relative">
-                    {editingSlotIndex === idx ? (
-                      <div className="absolute left-1/2 -translate-x-1/2 bg-white p-2 rounded-lg shadow-lg space-y-1 z-10">
-                        <input
-                          type="time"
-                          value={slotForm.start}
-                          onChange={(e) => setSlotForm({ ...slotForm, start: e.target.value })}
-                          className="border border-gray-300 rounded w-24 mb-1 px-1"
-                        />
-                        <input
-                          type="time"
-                          value={slotForm.end}
-                          onChange={(e) => setSlotForm({ ...slotForm, end: e.target.value })}
-                          className="border border-gray-300 rounded w-24 mb-1 px-1"
-                        />
-                        <div className="flex justify-end space-x-1 text-xs">
-                          <button onClick={() => { setEditingSlotIndex(null); }} className="text-gray-500">Annuler</button>
-                          <button
-                            onClick={() => {
-                              const updated = [...timeSlots];
-                              updated[idx] = `${slotForm.start}-${slotForm.end}`;
-                              setTimeSlots(updated);
-                              setEditingSlotIndex(null);
-                            }}
-                            className="text-primary"
-                          >OK</button>
-                        </div>
-                      </div>
-                    ) : (
-                      <button onClick={() => { const [s, e] = slot.split('-'); setSlotForm({ start: s, end: e }); setEditingSlotIndex(idx); }} className="hover:text-primary">
-                        {slot.replace('-', ' – ')}
-                      </button>
-                    )}
-                  </th>
-                ))}
-              </tr>
-            </thead>
+          <table className="w-full">
             <tbody className="divide-y divide-gray-200">
               {days.map(date => {
                 const dateObj = new Date(date);
@@ -311,36 +206,8 @@ export function AvailabilityCalendar() {
                           <span>Créneau perso</span>
                         </button>
                       </td>
-                      {timeSlots.map(slot => {
-                        const slotAvailabilities = getAvailabilityForSlot(date, slot);
-                        const available = slotAvailabilities.filter(a => a.isAvailable).length;
-                        const userAvailability = getUserAvailability(date, slot);
-
-                        return (
-                          <td key={slot} className="px-4 py-3 text-center">
-                            <button
-                              onClick={() => handleToggleAvailability(date, slot)}
-                              className="relative group w-full"
-                            >
-                              <div className={`w-12 h-12 mx-auto rounded-lg flex items-center justify-center transition-all ${
-                                getAvailabilityColor(available, total)
-                              } hover:scale-110`}>
-                                {userAvailability?.isAvailable ? (
-                                  <Check className="w-5 h-5 text-white" />
-                                ) : userAvailability?.isAvailable === false ? (
-                                  <X className="w-5 h-5 text-white" />
-                                ) : (
-                                  <Plus className="w-5 h-5 text-white opacity-70" />
-                                )}
-                              </div>
-                              <div className="absolute -top-8 left-1/2 transform -translate-x-1/2 bg-black text-white text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap">
-                                {available}/{total} disponibles
-                              </div>
-                            </button>
-                          </td>
-                        );
-                      })}
-                    </tr>
+                      {/* fixed time slots removed */}
+                   </tr>
                     {custom.map((slot, idx) => {
                       const slotId = `${slot.start}-${slot.end}`;
                       const availableCount = users.filter(u => confirmations[date]?.[slotId]?.[u.id]).length;
@@ -348,7 +215,7 @@ export function AvailabilityCalendar() {
                         <React.Fragment key={slotId}>
                           <tr className="bg-gray-50">
                             <td className="px-4 py-1" />
-                            <td colSpan={timeSlots.length} className="px-4 py-1 flex justify-between items-center text-sm">
+                            <td colSpan={1} className="px-4 py-1 flex justify-between items-center text-sm">
                               <span>
                                 {slot.start} – {slot.end}
                                 <span className="ml-2 text-xs text-gray-500">({availableCount}/{total} disponibles)</span>
@@ -379,7 +246,7 @@ export function AvailabilityCalendar() {
                           </tr>
                           <tr className="bg-gray-50">
                             <td className="px-4 py-1" />
-                            <td colSpan={timeSlots.length} className="px-4 py-1">
+                            <td colSpan={1} className="px-4 py-1">
                               <MemberAvailabilityRow
                                 members={users}
                                 date={date}
@@ -395,7 +262,7 @@ export function AvailabilityCalendar() {
                     {editingDate === date && (
                       <tr className="bg-gray-50">
                         <td className="px-4 py-2" />
-                        <td colSpan={timeSlots.length} className="px-4 py-2">
+                        <td colSpan={1} className="px-4 py-2">
                           <div className="flex items-center space-x-2">
                             <input
                               type="time"
@@ -442,51 +309,7 @@ export function AvailabilityCalendar() {
           />
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          {timeSlots.map(slot => {
-            const slotAvailabilities = getAvailabilityForSlot(selectedDate, slot);
-            const availableUsers = slotAvailabilities.filter(a => a.isAvailable);
-            const unavailableUsers = slotAvailabilities.filter(a => !a.isAvailable);
-            
-            return (
-              <div key={slot} className="border border-gray-200 rounded-lg p-4">
-                <h4 className="font-medium text-dark mb-3">{slot}</h4>
-                
-                <div className="space-y-2">
-                  <div>
-                    <p className="text-xs text-accent font-medium mb-1">
-                      Disponibles ({availableUsers.length})
-                    </p>
-                    {availableUsers.map(avail => {
-                      const user = users.find(u => u.id === avail.userId);
-                      return (
-                        <div key={avail.id} className="text-xs text-accent flex items-center">
-                          <Check className="w-3 h-3 mr-1" />
-                          {user?.name} ({user?.instrument})
-                        </div>
-                      );
-                    })}
-                  </div>
-                  
-                  <div>
-                    <p className="text-xs text-primary font-medium mb-1">
-                      Indisponibles ({unavailableUsers.length})
-                    </p>
-                    {unavailableUsers.map(avail => {
-                      const user = users.find(u => u.id === avail.userId);
-                      return (
-                        <div key={avail.id} className="text-xs text-primary flex items-center">
-                          <X className="w-3 h-3 mr-1" />
-                          {user?.name} ({user?.instrument})
-                        </div>
-                      );
-                    })}
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-        </div>
+        {/* fixed time slots view removed */}
       </div>
 
       {showModal && (

--- a/DocumentsPage.tsx
+++ b/DocumentsPage.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+
+interface StoredFile {
+  id: string;
+  file: File;
+}
+
+export function DocumentsPage() {
+  const [files, setFiles] = useState<StoredFile[]>([]);
+
+  const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(e.target.files || []).map((file) => ({
+      id: Math.random().toString(36).substr(2, 9),
+      file,
+    }));
+    setFiles((prev) => [...prev, ...selected]);
+    e.target.value = '';
+  };
+
+  const handleDelete = (id: string) => {
+    setFiles((prev) => prev.filter((f) => f.id !== id));
+  };
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold text-dark mb-4">Documents</h1>
+      <div className="mb-6">
+        <input type="file" multiple onChange={handleUpload} />
+      </div>
+      <ul className="space-y-2">
+        {files.map((f) => (
+          <li
+            key={f.id}
+            className="bg-white p-3 rounded-lg border border-gray-200 flex justify-between items-center"
+          >
+            <span className="text-sm">
+              {f.file.name} ({(f.file.size / 1024).toFixed(1)} ko)
+            </span>
+            <div className="flex space-x-2">
+              <a
+                href={URL.createObjectURL(f.file)}
+                download={f.file.name}
+                className="bg-primary text-white px-2 py-1 rounded text-xs"
+              >
+                Télécharger
+              </a>
+              <button
+                onClick={() => handleDelete(f.id)}
+                className="bg-red-500 text-white px-2 py-1 rounded text-xs"
+              >
+                Supprimer
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/IdeaBoardPage.tsx
+++ b/IdeaBoardPage.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { useApp } from './AppContext';
+
+interface Idea {
+  id: string;
+  text: string;
+  author: string;
+  date: string;
+  status: 'todo' | 'done';
+}
+
+export function IdeaBoardPage() {
+  const { state } = useApp();
+  const { currentUser } = state;
+  const [ideas, setIdeas] = useState<Idea[]>([]);
+  const [newIdea, setNewIdea] = useState('');
+
+  const addIdea = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newIdea.trim() || !currentUser) return;
+    const idea: Idea = {
+      id: Math.random().toString(36).substr(2, 9),
+      text: newIdea.trim(),
+      author: currentUser.name,
+      date: new Date().toISOString().split('T')[0],
+      status: 'todo'
+    };
+    setIdeas(prev => [...prev, idea]);
+    setNewIdea('');
+  };
+
+  const setStatus = (id: string, status: Idea['status']) => {
+    setIdeas(prev => prev.map(i => (i.id === id ? { ...i, status } : i)));
+  };
+
+  const pending = ideas.filter(i => i.status !== 'done');
+  const done = ideas.filter(i => i.status === 'done');
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold text-dark mb-4">Pense-Bête</h1>
+      <form onSubmit={addIdea} className="mb-6 flex space-x-2">
+        <input
+          type="text"
+          value={newIdea}
+          onChange={e => setNewIdea(e.target.value)}
+          className="flex-1 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+          placeholder="Nouvelle idée"
+        />
+        <button
+          type="submit"
+          className="bg-primary text-white px-4 py-2 rounded-lg font-medium"
+        >
+          Ajouter
+        </button>
+      </form>
+
+      <div className="space-y-4">
+        {pending.map(i => (
+          <div
+            key={i.id}
+            className="bg-white p-4 rounded-lg border border-gray-200 flex justify-between items-center"
+          >
+            <div>
+              <p className="text-sm font-medium text-dark">{i.text}</p>
+              <p className="text-xs text-gray-500">
+                {i.author} – {new Date(i.date).toLocaleDateString('fr-FR')}
+              </p>
+            </div>
+            <div className="flex space-x-2">
+              <button
+                onClick={() => setStatus(i.id, 'todo')}
+                className="bg-orange-500 text-white px-2 py-1 rounded text-xs"
+              >
+                À traiter
+              </button>
+              <button
+                onClick={() => setStatus(i.id, 'done')}
+                className="bg-green-600 text-white px-2 py-1 rounded text-xs"
+              >
+                Traité
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {done.length > 0 && (
+        <div className="mt-8">
+          <h2 className="text-lg font-bold text-dark mb-2">Traité</h2>
+          <div className="space-y-2">
+            {done.map(i => (
+              <div
+                key={i.id}
+                className="bg-white p-3 rounded-lg border border-gray-200 flex justify-between items-center"
+              >
+                <div>
+                  <p className="text-sm text-dark">{i.text}</p>
+                  <p className="text-xs text-gray-500">
+                    {i.author} – {new Date(i.date).toLocaleDateString('fr-FR')}
+                  </p>
+                </div>
+                <div className="flex space-x-2">
+                  <button
+                    onClick={() => setStatus(i.id, 'todo')}
+                    className="bg-orange-500 text-white px-2 py-1 rounded text-xs"
+                  >
+                    À traiter
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/Navigation.tsx
+++ b/Navigation.tsx
@@ -4,6 +4,8 @@ import {
   Calendar,
   CalendarDays,
   Mic,
+  StickyNote,
+  FileText,
   Users,
   Settings,
   LogOut,
@@ -23,6 +25,8 @@ export function Navigation() {
     { id: 'calendar' as const, label: 'Calendrier', icon: CalendarDays },
     { id: 'concerts' as const, label: 'Concerts', icon: Mic },
     { id: 'contacts' as const, label: 'Contacts', icon: Users },
+    { id: 'ideas' as const, label: 'Pense-Bête', icon: StickyNote },
+    { id: 'documents' as const, label: 'Documents', icon: FileText },
     ...(currentUser?.role === 'admin' ? [{ id: 'admin' as const, label: 'Administration', icon: Settings }] : []),
   ];
 

--- a/index.ts
+++ b/index.ts
@@ -46,6 +46,14 @@ export interface AppState {
   availabilities: Availability[];
   concerts: Concert[];
   contacts: Contact[];
-  currentTab: 'dashboard' | 'availability' | 'calendar' | 'concerts' | 'contacts' | 'admin';
+  currentTab:
+    | 'dashboard'
+    | 'availability'
+    | 'calendar'
+    | 'concerts'
+    | 'contacts'
+    | 'ideas'
+    | 'documents'
+    | 'admin';
   isDarkMode: boolean;
 }


### PR DESCRIPTION
## Summary
- remove fixed slot table and add button from AvailabilityCalendar
- integrate IdeaBoard and Documents pages with local state
- update navigation and app routing
- extend tab types for ideas and documents

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685674566ea883268af78b9a28fd189f