### PR TITLE
Update events and textarea

### DIFF
--- a/IdeaBoardPage.tsx
+++ b/IdeaBoardPage.tsx
@@ -66,14 +66,25 @@ export function IdeaBoardPage() {
   return (
     <div className="p-6 max-w-4xl mx-auto">
       <h1 className="text-3xl font-bold text-dark mb-4">Pense-Bête</h1>
-      <form onSubmit={addIdea} className="mb-6 flex space-x-2">
-        <input
-          type="text"
-          value={newIdea}
-          onChange={e => setNewIdea(e.target.value)}
-          className="flex-1 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
-          placeholder="Nouvelle idée"
-        />
+      <form onSubmit={addIdea} className="mb-6 space-y-2">
+        <div>
+          <textarea
+            value={newIdea}
+            onChange={e => setNewIdea(e.target.value)}
+            maxLength={2500}
+            className="w-full resize-none rounded-lg px-3 py-2 border focus:ring-2 focus:ring-accent focus:border-transparent"
+            placeholder="Nouvelle idée"
+            style={{
+              fontFamily: 'Roboto, sans-serif',
+              backgroundColor: '#F9FAFB',
+              borderColor: '#CBD5E1',
+              color: '#374151'
+            }}
+          />
+          <div className="text-right text-xs text-gray-500 mt-1">
+            {newIdea.length} / 2500
+          </div>
+        </div>
         <button
           type="submit"
           className="bg-primary text-white px-4 py-2 rounded-lg font-medium"

--- a/data/events.ts
+++ b/data/events.ts
@@ -8,7 +8,52 @@ export interface CalendarEvent {
 }
 
 export const events: CalendarEvent[] = [
-  { id: '1', title: 'Répétition générale', date: '2024-06-21', time: '19:00', type: 'rehearsal', location: 'Local de répétition' },
-  { id: '2', title: 'Concert au parc', date: '2024-06-22', time: '20:00', type: 'gig', location: 'Parc Central' },
-  { id: '3', title: "Concert d'été", date: '2024-06-28', time: '21:00', type: 'gig', location: 'Salle des Fêtes' },
+  {
+    id: '1',
+    title: 'Répétition de printemps',
+    date: '2025-03-15',
+    time: '18:00',
+    type: 'rehearsal',
+    location: 'Studio A'
+  },
+  {
+    id: '2',
+    title: 'Répétition générale',
+    date: '2025-05-20',
+    time: '19:30',
+    type: 'rehearsal',
+    location: 'Local de répétition'
+  },
+  {
+    id: '3',
+    title: 'Répétition acoustique',
+    date: '2025-09-10',
+    time: '17:00',
+    type: 'rehearsal',
+    location: 'Studio B'
+  },
+  {
+    id: '4',
+    title: 'Concert au parc',
+    date: '2025-07-01',
+    time: '20:00',
+    type: 'gig',
+    location: 'Parc Central'
+  },
+  {
+    id: '5',
+    title: "Festival d'été",
+    date: '2025-08-15',
+    time: '21:00',
+    type: 'gig',
+    location: 'Grand Théâtre'
+  },
+  {
+    id: '6',
+    title: 'Jam du jour',
+    date: new Date().toISOString().split('T')[0],
+    time: '18:00',
+    type: 'rehearsal',
+    location: 'Studio C'
+  }
 ];


### PR DESCRIPTION
## Summary
- add fresh sample events for 2025
- allow adding ideas with a textarea and live counter

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856840a16108326864dc45b6a5619f6