### PR TITLE
Add event navigation and edit options

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { LoginForm } from './LoginForm';
 import { Navigation } from './Navigation';
 import { Dashboard } from './Dashboard';
 import { AvailabilityCalendar } from './AvailabilityCalendar';
+import { Routes, Route } from 'react-router-dom';
 const CalendarPage = React.lazy(() => import('./CalendarPage').then(m => ({ default: m.CalendarPage }))); 
 const ConcertManagement = React.lazy(() => import('./ConcertManagement').then(m => ({ default: m.ConcertManagement })));
 const ContactDirectory = React.lazy(() => import('./ContactDirectory').then(m => ({ default: m.ContactDirectory })));
@@ -70,7 +71,10 @@ function App() {
   return (
     <EventsProvider>
       <AppProvider>
-        <AppContent />
+        <Routes>
+          <Route path="/concerts/:eventId" element={<AppContent />} />
+          <Route path="*" element={<AppContent />} />
+        </Routes>
       </AppProvider>
     </EventsProvider>
   );

--- a/CalendarPage.tsx
+++ b/CalendarPage.tsx
@@ -2,13 +2,17 @@ import React, { useState } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import { EventApi } from '@fullcalendar/core';
-import { useEvents } from './useEvents';
+import { useEvents, Event } from './useEvents';
 import { useApp } from './AppContext';
+import { useNavigate } from 'react-router-dom';
+import { EventFormModal } from './EventFormModal';
 
 export function CalendarPage() {
   const { dispatch } = useApp();
+  const navigate = useNavigate();
   const { events } = useEvents();
   const [selected, setSelected] = useState<EventApi | null>(null);
+  const [editingEvent, setEditingEvent] = useState<Event | null>(null);
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
@@ -26,6 +30,14 @@ export function CalendarPage() {
           extendedProps: { location: e.location, time: e.time, type: e.type }
         }))}
         eventClick={(info) => setSelected(info.event)}
+        eventDidMount={(info) => {
+          info.el.addEventListener('dblclick', () => {
+            const ev = events.find(e => e.id === info.event.id);
+            if (ev) {
+              setEditingEvent(ev);
+            }
+          });
+        }}
         height="auto"
       />
       {selected && (
@@ -59,6 +71,19 @@ export function CalendarPage() {
             >
               Voir disponibilités
             </button>
+            <button
+              className="block mt-1 text-primary text-sm underline"
+              onClick={() => {
+                if (selected) {
+                  const id = selected.id;
+                  setSelected(null);
+                  dispatch({ type: 'SET_TAB', payload: 'concerts' });
+                  navigate(`/concerts/${id}`);
+                }
+              }}
+            >
+              Voir l'événement
+            </button>
             <div className="mt-4 text-right">
               <button
                 onClick={() => setSelected(null)}
@@ -69,6 +94,9 @@ export function CalendarPage() {
             </div>
           </div>
         </div>
+      )}
+      {editingEvent && (
+        <EventFormModal event={editingEvent} onClose={() => setEditingEvent(null)} />
       )}
     </div>
   );

--- a/ConcertManagement.tsx
+++ b/ConcertManagement.tsx
@@ -1,60 +1,34 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Plus, Calendar, MapPin, Edit, Trash2 } from 'lucide-react';
 import { useEvents, Event as EventType } from './useEvents';
+import { useNavigate, useParams } from 'react-router-dom';
+import { EventFormModal } from './EventFormModal';
 
 export function ConcertManagement() {
-  const { events, createEvent, updateEvent, deleteEvent } = useEvents();
+  const { events, deleteEvent } = useEvents();
+  const navigate = useNavigate();
+  const { eventId } = useParams<{ eventId?: string }>();
   const [showModal, setShowModal] = useState(false);
   const [editingEvent, setEditingEvent] = useState<EventType | null>(null);
-  const [formData, setFormData] = useState({
-    title: '',
-    date: '',
-    time: '',
-    location: '',
-    type: 'rehearsal' as EventType['type'],
-  });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    const data = {
-      title: formData.title,
-      date: formData.date,
-      time: formData.time,
-      location: formData.location,
-      type: formData.type,
-    };
-
-    if (editingEvent) {
-      updateEvent({ ...editingEvent, ...data });
-    } else {
-      createEvent(data);
+  useEffect(() => {
+    if (eventId) {
+      const ev = events.find(e => e.id === eventId);
+      if (ev) {
+        setEditingEvent(ev);
+        setShowModal(true);
+      }
     }
-
-    resetForm();
-  };
+  }, [eventId, events]);
 
   const resetForm = () => {
-    setFormData({
-      title: '',
-      date: '',
-      time: '',
-      location: '',
-      type: 'rehearsal',
-    });
     setEditingEvent(null);
     setShowModal(false);
+    navigate('/concerts');
   };
 
   const handleEdit = (ev: EventType) => {
     setEditingEvent(ev);
-    setFormData({
-      title: ev.title,
-      date: ev.date,
-      time: ev.time,
-      location: ev.location,
-      type: ev.type,
-    });
     setShowModal(true);
   };
 
@@ -97,7 +71,10 @@ export function ConcertManagement() {
           </p>
         </div>
         <button
-          onClick={() => setShowModal(true)}
+          onClick={() => {
+            setEditingEvent(null);
+            setShowModal(true);
+          }}
           className="bg-primary text-white px-4 py-2 rounded-lg font-medium hover:bg-primary/90 transition-colors flex items-center space-x-2 focus:outline-none focus:ring-2 focus:ring-accent"
         >
           <Plus className="w-5 h-5" />
@@ -163,106 +140,11 @@ export function ConcertManagement() {
             </div>
           );
         })}
+      {showModal && (
+        <EventFormModal event={editingEvent || undefined} onClose={resetForm} />
+      )}
       </div>
 
-      {/* Modal */}
-      {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-xl p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-            <h2 className="text-2xl font-bold text-dark mb-6">
-              {editingEvent ? 'Modifier l\'événement' : 'Nouvel événement'}
-            </h2>
-
-            <form onSubmit={handleSubmit} className="space-y-6">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Titre *
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.title}
-                    onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
-                    required
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Type *
-                  </label>
-                  <select
-                    value={formData.type}
-                    onChange={(e) => setFormData({ ...formData, type: e.target.value as EventType['type'] })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
-                  >
-                    <option value="rehearsal">Répétition</option>
-                    <option value="gig">Concert</option>
-                  </select>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Date *
-                  </label>
-                  <input
-                    type="date"
-                    value={formData.date}
-                    onChange={(e) => setFormData({ ...formData, date: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
-                    required
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Heure *
-                  </label>
-                  <input
-                    type="time"
-                    value={formData.time}
-                    onChange={(e) => setFormData({ ...formData, time: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
-                    required
-                  />
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Lieu *
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.location}
-                    onChange={(e) => setFormData({ ...formData, location: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
-                    required
-                  />
-                </div>
-              </div>
-
-
-
-              <div className="flex justify-end space-x-4">
-                <button
-                  type="button"
-                  onClick={resetForm}
-                  className="px-4 py-2 text-gray-600 hover:text-dark font-medium"
-                >
-                  Annuler
-                </button>
-                <button
-                  type="submit"
-                  className="bg-primary text-white px-6 py-2 rounded-lg font-medium hover:bg-primary/90 transition-colors focus:outline-none focus:ring-2 focus:ring-accent"
-                >
-                  {editingEvent ? 'Modifier' : 'Créer'}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/EventFormModal.tsx
+++ b/EventFormModal.tsx
@@ -1,0 +1,114 @@
+import React, { useState, useEffect } from 'react';
+import { useEvents, Event as EventType } from './useEvents';
+
+interface EventFormModalProps {
+  event?: EventType;
+  onClose: () => void;
+}
+
+export function EventFormModal({ event, onClose }: EventFormModalProps) {
+  const { createEvent, updateEvent } = useEvents();
+  const [formData, setFormData] = useState({
+    title: '',
+    date: '',
+    time: '',
+    location: '',
+    type: 'rehearsal' as EventType['type'],
+  });
+
+  useEffect(() => {
+    if (event) {
+      setFormData({
+        title: event.title,
+        date: event.date,
+        time: event.time,
+        location: event.location,
+        type: event.type,
+      });
+    }
+  }, [event]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data = { ...formData };
+    if (event) {
+      updateEvent({ ...event, ...data });
+    } else {
+      createEvent(data);
+    }
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-xl p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+        <h2 className="text-2xl font-bold text-dark mb-6">
+          {event ? "Modifier l'événement" : 'Nouvel événement'}
+        </h2>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Titre *</label>
+              <input
+                type="text"
+                value={formData.title}
+                onChange={e => setFormData({ ...formData, title: e.target.value })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Type *</label>
+              <select
+                value={formData.type}
+                onChange={e => setFormData({ ...formData, type: e.target.value as EventType['type'] })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+              >
+                <option value="rehearsal">Répétition</option>
+                <option value="gig">Concert</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Date *</label>
+              <input
+                type="date"
+                value={formData.date}
+                onChange={e => setFormData({ ...formData, date: e.target.value })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Heure *</label>
+              <input
+                type="time"
+                value={formData.time}
+                onChange={e => setFormData({ ...formData, time: e.target.value })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Lieu *</label>
+              <input
+                type="text"
+                value={formData.location}
+                onChange={e => setFormData({ ...formData, location: e.target.value })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+                required
+              />
+            </div>
+          </div>
+          <div className="flex justify-end space-x-4">
+            <button type="button" onClick={onClose} className="px-4 py-2 text-gray-600 hover:text-dark font-medium">
+              Annuler
+            </button>
+            <button type="submit" className="bg-primary text-white px-6 py-2 rounded-lg font-medium hover:bg-primary/90 transition-colors focus:outline-none focus:ring-2 focus:ring-accent">
+              {event ? 'Modifier' : 'Créer'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/IdeaBoardPage.tsx
+++ b/IdeaBoardPage.tsx
@@ -47,7 +47,8 @@ export function IdeaBoardPage() {
       prev.map(i => (i.id === id ? { ...i, text: editValues[id], isEditing: false } : i))
     );
     setEditValues(prev => {
-      const { [id]: _removed, ...rest } = prev;
+      const rest = { ...prev };
+      delete rest[id];
       return rest;
     });
   };
@@ -55,7 +56,8 @@ export function IdeaBoardPage() {
   const cancelEdit = (id: string) => {
     setIdeas(prev => prev.map(i => (i.id === id ? { ...i, isEditing: false } : i)));
     setEditValues(prev => {
-      const { [id]: _removed, ...rest } = prev;
+      const rest = { ...prev };
+      delete rest[id];
       return rest;
     });
   };
@@ -68,21 +70,16 @@ export function IdeaBoardPage() {
       <h1 className="text-3xl font-bold text-dark mb-4">Pense-Bête</h1>
       <form onSubmit={addIdea} className="mb-6 space-y-2">
         <div>
-          <textarea
+          <label className="block text-sm font-medium text-gray-700 mb-1">Titre</label>
+          <input
+            type="text"
             value={newIdea}
             onChange={e => setNewIdea(e.target.value)}
-            maxLength={2500}
-            className="w-full resize-none rounded-lg px-3 py-2 border focus:ring-2 focus:ring-accent focus:border-transparent"
-            placeholder="Nouvelle idée"
-            style={{
-              fontFamily: 'Roboto, sans-serif',
-              backgroundColor: '#F9FAFB',
-              borderColor: '#CBD5E1',
-              color: '#374151'
-            }}
+            maxLength={15}
+            className="w-full rounded-lg px-3 py-2 border focus:ring-2 focus:ring-accent focus:border-transparent"
           />
           <div className="text-right text-xs text-gray-500 mt-1">
-            {newIdea.length} / 2500
+            {newIdea.length} / 15
           </div>
         </div>
         <button
@@ -101,14 +98,21 @@ export function IdeaBoardPage() {
           >
             <div>
               {i.isEditing ? (
-                <input
-                  type="text"
-                  value={editValues[i.id] || ''}
-                  onChange={e =>
-                    setEditValues(prev => ({ ...prev, [i.id]: e.target.value }))
-                  }
-                  className="border border-gray-300 rounded-lg px-3 py-1 text-sm focus:ring-2 focus:ring-accent focus:border-transparent"
-                />
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-1">Info</label>
+                  <textarea
+                    value={editValues[i.id] || ''}
+                    onChange={e =>
+                      setEditValues(prev => ({ ...prev, [i.id]: e.target.value }))
+                    }
+                    maxLength={3000}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-1 text-sm focus:ring-2 focus:ring-accent focus:border-transparent resize-none"
+                    rows={3}
+                  />
+                  <div className="text-right text-xs text-gray-500 mt-1">
+                    {(editValues[i.id] || '').length} / 3000
+                  </div>
+                </div>
               ) : (
                 <>
                   <p className="text-sm font-medium text-dark">{i.text}</p>
@@ -170,14 +174,21 @@ export function IdeaBoardPage() {
               >
                 <div>
                   {i.isEditing ? (
-                    <input
-                      type="text"
-                      value={editValues[i.id] || ''}
-                      onChange={e =>
-                        setEditValues(prev => ({ ...prev, [i.id]: e.target.value }))
-                      }
-                      className="border border-gray-300 rounded-lg px-3 py-1 text-sm focus:ring-2 focus:ring-accent focus:border-transparent"
-                    />
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700 mb-1">Info</label>
+                      <textarea
+                        value={editValues[i.id] || ''}
+                        onChange={e =>
+                          setEditValues(prev => ({ ...prev, [i.id]: e.target.value }))
+                        }
+                        maxLength={3000}
+                        className="w-full border border-gray-300 rounded-lg px-3 py-1 text-sm focus:ring-2 focus:ring-accent focus:border-transparent resize-none"
+                        rows={3}
+                      />
+                      <div className="text-right text-xs text-gray-500 mt-1">
+                        {(editValues[i.id] || '').length} / 3000
+                      </div>
+                    </div>
                   ) : (
                     <>
                       <p className="text-sm text-dark">{i.text}</p>

--- a/main.tsx
+++ b/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@fullcalendar/react": "^6.1.17",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -1025,6 +1026,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3320,6 +3330,38 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@fullcalendar/react": "^6.1.17",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
## Summary
- enable routing with `BrowserRouter`
- create reusable `EventFormModal` for event add/edit
- show edit modal on calendar double-click and allow viewing event page
- update concerts page to open modal via routes
- adjust idea board: title field, info textarea with char counter

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685686c90ec083268ae3f43013918428