### PR TITLE
Add Idea info modal and calendar event creation

### DIFF
--- a/AddEventModal.tsx
+++ b/AddEventModal.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import { useEvents } from './useEvents';
+
+interface AddEventModalProps {
+  date: string;
+  onClose: () => void;
+}
+
+export function AddEventModal({ date, onClose }: AddEventModalProps) {
+  const { createEvent } = useEvents();
+  const [form, setForm] = useState({
+    title: '',
+    date,
+    startTime: '',
+    endTime: '',
+    location: '',
+    description: '',
+    type: 'rehearsal' as const,
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    createEvent({
+      title: form.title,
+      date: form.date,
+      time: form.startTime,
+      endTime: form.endTime,
+      location: form.location,
+      description: form.description,
+      type: form.type,
+    });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-xl p-6 w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <h2 className="text-2xl font-bold text-dark mb-6">Nouvel événement</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Type</label>
+            <div className="flex space-x-4">
+              <label className="flex items-center space-x-1">
+                <input
+                  type="radio"
+                  checked={form.type === 'rehearsal'}
+                  onChange={() => setForm({ ...form, type: 'rehearsal' })}
+                />
+                <span>Répétition</span>
+              </label>
+              <label className="flex items-center space-x-1">
+                <input
+                  type="radio"
+                  checked={form.type === 'gig'}
+                  onChange={() => setForm({ ...form, type: 'gig' })}
+                />
+                <span>Concert</span>
+              </label>
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Titre</label>
+            <input
+              type="text"
+              value={form.title}
+              onChange={(e) => setForm({ ...form, title: e.target.value })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Date</label>
+            <input
+              type="date"
+              value={form.date}
+              onChange={(e) => setForm({ ...form, date: e.target.value })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+              required
+            />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Heure de début</label>
+              <input
+                type="time"
+                value={form.startTime}
+                onChange={(e) => setForm({ ...form, startTime: e.target.value })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">Heure de fin</label>
+              <input
+                type="time"
+                value={form.endTime}
+                onChange={(e) => setForm({ ...form, endTime: e.target.value })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+                required
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Lieu</label>
+            <input
+              type="text"
+              value={form.location}
+              onChange={(e) => setForm({ ...form, location: e.target.value })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Description</label>
+            <textarea
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent resize-none"
+              rows={3}
+            />
+          </div>
+          <div className="flex justify-end space-x-4">
+            <button type="button" onClick={onClose} className="px-4 py-2 text-gray-600 hover:text-dark font-medium">
+              Annuler
+            </button>
+            <button type="submit" className="bg-primary text-white px-6 py-2 rounded-lg font-medium hover:bg-primary/90 transition-colors focus:outline-none focus:ring-2 focus:ring-accent">
+              Créer
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/CalendarPage.tsx
+++ b/CalendarPage.tsx
@@ -6,6 +6,7 @@ import { useEvents, Event } from './useEvents';
 import { useApp } from './AppContext';
 import { useNavigate } from 'react-router-dom';
 import { EventFormModal } from './EventFormModal';
+import { AddEventModal } from './AddEventModal';
 
 export function CalendarPage() {
   const { dispatch } = useApp();
@@ -13,6 +14,7 @@ export function CalendarPage() {
   const { events } = useEvents();
   const [selected, setSelected] = useState<EventApi | null>(null);
   const [editingEvent, setEditingEvent] = useState<Event | null>(null);
+  const [creatingDate, setCreatingDate] = useState<string | null>(null);
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
@@ -21,13 +23,34 @@ export function CalendarPage() {
         plugins={[dayGridPlugin]}
         initialView="dayGridMonth"
         locale="fr"
+        dayCellContent={(arg) => {
+          const dateStr = arg.date.toISOString().split('T')[0];
+          return (
+            <div className="relative h-full">
+              <span>{arg.dayNumberText}</span>
+              <button
+                type="button"
+                onClick={() => setCreatingDate(dateStr)}
+                className="absolute top-0 right-0 w-6 h-6 flex items-center justify-center text-xs bg-primary text-white rounded opacity-50 hover:opacity-100"
+              >
+                +
+              </button>
+            </div>
+          );
+        }}
         events={events.map(e => ({
           id: e.id,
           title: e.title,
           date: e.date,
           backgroundColor: e.type === 'rehearsal' ? '#60A5FA' : '#A78BFA',
           borderColor: e.type === 'rehearsal' ? '#60A5FA' : '#A78BFA',
-          extendedProps: { location: e.location, time: e.time, type: e.type }
+          extendedProps: {
+            location: e.location,
+            time: e.time,
+            endTime: e.endTime,
+            description: e.description,
+            type: e.type,
+          }
         }))}
         eventClick={(info) => setSelected(info.event)}
         eventDidMount={(info) => {
@@ -46,6 +69,7 @@ export function CalendarPage() {
             <h2 className="text-xl font-bold text-dark mb-2">{selected.title}</h2>
             <p className="text-sm mb-2">
               {selected.extendedProps.location} - {selected.extendedProps.time}
+              {selected.extendedProps.endTime ? ` - ${selected.extendedProps.endTime}` : ''}
             </p>
             <a
               href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(selected.extendedProps.location)}`}
@@ -97,6 +121,9 @@ export function CalendarPage() {
       )}
       {editingEvent && (
         <EventFormModal event={editingEvent} onClose={() => setEditingEvent(null)} />
+      )}
+      {creatingDate && (
+        <AddEventModal date={creatingDate} onClose={() => setCreatingDate(null)} />
       )}
     </div>
   );

--- a/InfoModal.tsx
+++ b/InfoModal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+interface InfoModalProps {
+  value: string;
+  onChange: (val: string) => void;
+  onClose: () => void;
+}
+
+export function InfoModal({ value, onChange, onClose }: InfoModalProps) {
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-xl p-6 w-full max-w-2xl">
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          maxLength={3000}
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent resize-none h-[400px]"
+        />
+        <div className="text-right text-xs text-gray-500 mt-1">
+          {value.length} / 3000
+        </div>
+        <div className="mt-4 text-right">
+          <button
+            onClick={onClose}
+            className="bg-primary text-white px-4 py-2 rounded-lg"
+          >
+            Fermer
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/data/events.ts
+++ b/data/events.ts
@@ -3,6 +3,8 @@ export interface CalendarEvent {
   title: string;
   date: string;
   time: string;
+  endTime?: string;
+  description?: string;
   type: 'rehearsal' | 'gig';
   location: string;
 }


### PR DESCRIPTION
## Summary
- expand Info field in IdeaBoard using a modal
- allow longer titles and add character counters
- add AddEventModal and '+' button for calendar days
- show time ranges in CalendarPage
- extend event type with description and end time

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68568ac2c0988326b1e122c57ab722a7