### PR TITLE
Restrict toggling to current user and move calendar button

### DIFF
--- a/CalendarPage.tsx
+++ b/CalendarPage.tsx
@@ -26,12 +26,12 @@ export function CalendarPage() {
         dayCellContent={(arg) => {
           const dateStr = arg.date.toISOString().split('T')[0];
           return (
-            <div className="relative h-full">
+            <div className="day-cell h-full">
               <span>{arg.dayNumberText}</span>
               <button
                 type="button"
                 onClick={() => setCreatingDate(dateStr)}
-                className="absolute top-0 right-0 w-6 h-6 flex items-center justify-center text-xs bg-primary text-white rounded opacity-50 hover:opacity-100"
+                className="add-slot-btn w-6 h-6 flex items-center justify-center text-xs bg-primary text-white rounded opacity-50 hover:opacity-100"
               >
                 +
               </button>

--- a/MemberAvailabilityRow.tsx
+++ b/MemberAvailabilityRow.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { User } from './index';
+import { useApp } from './AppContext';
 
 export interface ConfirmationsState {
   [date: string]: {
@@ -18,7 +19,11 @@ interface Props {
 }
 
 export function MemberAvailabilityRow({ members, date, slotId, confirmations, setConfirmations }: Props) {
+  const { state } = useApp();
+  const currentUser = state.currentUser;
+
   const toggle = (memberId: string) => {
+    if (!currentUser || currentUser.id !== memberId) return;
     setConfirmations(prev => {
       const dateConf = prev[date] || {};
       const slotConf = dateConf[slotId] || {};
@@ -46,12 +51,14 @@ export function MemberAvailabilityRow({ members, date, slotId, confirmations, se
         return (
           <div key={m.id} className="flex items-center justify-between text-sm">
             <span>{m.name}</span>
-            <button
-              onClick={() => toggle(m.id)}
-              className={`text-white px-2 py-1 rounded ${available ? 'bg-green-500' : 'bg-red-500'}`}
-            >
-              {available ? '✅' : '❌'}
-            </button>
+            {currentUser?.id === m.id && (
+              <button
+                onClick={() => toggle(m.id)}
+                className={`text-white px-2 py-1 rounded ${available ? 'bg-green-500' : 'bg-red-500'}`}
+              >
+                {available ? '✅' : '❌'}
+              </button>
+            )}
           </div>
         );
       })}

--- a/index.css
+++ b/index.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.day-cell {
+  position: relative;
+}
+
+.add-slot-btn {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+}


### PR DESCRIPTION
## Summary
- only show availability toggle for logged in member
- prevent toggling availability when not the current user
- place calendar add-slot button at the top-left of the day cell
- add supporting CSS for `.day-cell` and `.add-slot-btn`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68568e22b17c832680707d2511fe7c7e