### PR TITLE
Fix day cell add slot button position

### DIFF
--- a/CalendarPage.tsx
+++ b/CalendarPage.tsx
@@ -27,14 +27,14 @@ export function CalendarPage() {
           const dateStr = arg.date.toISOString().split('T')[0];
           return (
             <div className="day-cell h-full">
-              <span>{arg.dayNumberText}</span>
               <button
                 type="button"
                 onClick={() => setCreatingDate(dateStr)}
-                className="add-slot-btn w-6 h-6 flex items-center justify-center text-xs bg-primary text-white rounded opacity-50 hover:opacity-100"
+                className="add-slot-btn flex items-center justify-center text-xs opacity-50 hover:opacity-100"
               >
                 +
               </button>
+              <span>{arg.dayNumberText}</span>
             </div>
           );
         }}

--- a/index.css
+++ b/index.css
@@ -9,5 +9,16 @@
 .add-slot-btn {
   position: absolute;
   top: 4px;
-  left: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.add-slot-btn:focus {
+  outline: none;
+  box-shadow: none;
 }


### PR DESCRIPTION
## Summary
- move the day cell button above the day number
- style button in `index.css` so it sits centered at the top of the cell

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68568fd3b8388326b12fc36d40c50467