### PR TITLE
Improve calendar add button and info editor

### DIFF
--- a/CalendarPage.tsx
+++ b/CalendarPage.tsx
@@ -30,7 +30,7 @@ export function CalendarPage() {
               <button
                 type="button"
                 onClick={() => setCreatingDate(dateStr)}
-                className="add-slot-btn flex items-center justify-center text-xs opacity-50 hover:opacity-100"
+                className="add-slot-btn flex items-center justify-center text-xs hover:opacity-80"
               >
                 +
               </button>

--- a/IdeaBoardPage.tsx
+++ b/IdeaBoardPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useApp } from './AppContext';
 import { InfoModal } from './InfoModal';
+import { InfoEditor } from './InfoEditor';
 
 interface Idea {
   id: string;
@@ -91,14 +92,8 @@ export function IdeaBoardPage() {
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">Info</label>
-          <textarea
-            value={newInfo}
-            onChange={e => setNewInfo(e.target.value)}
-            maxLength={3000}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-accent focus:border-transparent resize-none h-[100px]"
-          />
-          <div className="flex items-center justify-between mt-1">
-            <span className="text-xs text-gray-500">{newInfo.length} / 3000</span>
+          <InfoEditor value={newInfo} onChange={setNewInfo} />
+          <div className="flex items-center justify-end mt-1">
             <button
               type="button"
               onClick={() => setShowInfoModal(true)}
@@ -133,18 +128,13 @@ export function IdeaBoardPage() {
               {i.isEditing ? (
                 <div>
                   <label className="block text-xs font-medium text-gray-700 mb-1">Info</label>
-                  <textarea
+                  <InfoEditor
                     value={editValues[i.id] || ''}
-                    onChange={e =>
-                      setEditValues(prev => ({ ...prev, [i.id]: e.target.value }))
+                    onChange={(val) =>
+                      setEditValues(prev => ({ ...prev, [i.id]: val }))
                     }
-                    maxLength={3000}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-1 text-sm focus:ring-2 focus:ring-accent focus:border-transparent resize-none h-[100px]"
                   />
-                  <div className="flex items-center justify-between mt-1">
-                    <span className="text-xs text-gray-500">
-                      {(editValues[i.id] || '').length} / 3000
-                    </span>
+                  <div className="flex items-center justify-end mt-1">
                     <button
                       type="button"
                       onClick={() => setExpandedInfoId(i.id)}
@@ -226,18 +216,13 @@ export function IdeaBoardPage() {
                   {i.isEditing ? (
                     <div>
                       <label className="block text-xs font-medium text-gray-700 mb-1">Info</label>
-                      <textarea
+                      <InfoEditor
                         value={editValues[i.id] || ''}
-                        onChange={e =>
-                          setEditValues(prev => ({ ...prev, [i.id]: e.target.value }))
+                        onChange={(val) =>
+                          setEditValues(prev => ({ ...prev, [i.id]: val }))
                         }
-                        maxLength={3000}
-                        className="w-full border border-gray-300 rounded-lg px-3 py-1 text-sm focus:ring-2 focus:ring-accent focus:border-transparent resize-none h-[100px]"
                       />
-                      <div className="flex items-center justify-between mt-1">
-                        <span className="text-xs text-gray-500">
-                          {(editValues[i.id] || '').length} / 3000
-                        </span>
+                      <div className="flex items-center justify-end mt-1">
                         <button
                           type="button"
                           onClick={() => setExpandedInfoId(i.id)}

--- a/InfoEditor.tsx
+++ b/InfoEditor.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useRef } from 'react';
+
+interface InfoEditorProps {
+  value: string;
+  onChange: (val: string) => void;
+  maxLength?: number;
+}
+
+export function InfoEditor({ value, onChange, maxLength = 3000 }: InfoEditorProps) {
+  const divRef = useRef<HTMLDivElement>(null);
+  const lastValue = useRef(value);
+
+  useEffect(() => {
+    if (divRef.current && divRef.current.innerHTML !== value) {
+      divRef.current.innerHTML = value;
+    }
+    lastValue.current = value;
+  }, [value]);
+
+  const exec = (command: string, val?: string) => {
+    document.execCommand('styleWithCSS', false, 'true');
+    document.execCommand(command, false, val);
+    if (divRef.current) {
+      onChange(divRef.current.innerHTML);
+      lastValue.current = divRef.current.innerHTML;
+    }
+  };
+
+  const handleInput = () => {
+    const el = divRef.current;
+    if (!el) return;
+    const textLength = el.innerText.length;
+    if (textLength > maxLength) {
+      el.innerHTML = lastValue.current;
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      range.collapse(false);
+      const sel = window.getSelection();
+      sel?.removeAllRanges();
+      sel?.addRange(range);
+      return;
+    }
+    lastValue.current = el.innerHTML;
+    onChange(el.innerHTML);
+  };
+
+  const textLength = divRef.current?.innerText.length ?? value.replace(/<[^>]*>/g, '').length;
+
+  return (
+    <div className="border border-gray-300 rounded-lg">
+      <div className="flex items-center space-x-2 p-2 border-b">
+        <select
+          className="border rounded px-1 text-xs"
+          defaultValue="3"
+          onChange={(e) => exec('fontSize', e.target.value)}
+        >
+          <option value="2">Petit</option>
+          <option value="3">Normal</option>
+          <option value="5">Grand</option>
+        </select>
+        <button
+          type="button"
+          onClick={() => exec('underline')}
+          className="text-sm font-bold px-1 border rounded"
+        >
+          U
+        </button>
+        <div className="flex space-x-1">
+          {['#000000', '#dc2626', '#2563eb', '#16a34a'].map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => exec('foreColor', c)}
+              style={{ backgroundColor: c }}
+              className="w-4 h-4 rounded border"
+            />
+          ))}
+        </div>
+      </div>
+      <div
+        ref={divRef}
+        className="p-2 h-[200px] overflow-auto focus:outline-none"
+        contentEditable
+        onInput={handleInput}
+      />
+      <div className="text-right text-xs text-gray-500 border-t px-2 py-1">
+        {textLength} / {maxLength}
+      </div>
+    </div>
+  );
+}

--- a/InfoModal.tsx
+++ b/InfoModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { InfoEditor } from './InfoEditor';
 
 interface InfoModalProps {
   value: string;
@@ -10,15 +11,7 @@ export function InfoModal({ value, onChange, onClose }: InfoModalProps) {
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
       <div className="bg-white rounded-xl p-6 w-full max-w-2xl">
-        <textarea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          maxLength={3000}
-          className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-accent focus:border-transparent resize-none h-[400px]"
-        />
-        <div className="text-right text-xs text-gray-500 mt-1">
-          {value.length} / 3000
-        </div>
+        <InfoEditor value={value} onChange={onChange} />
         <div className="mt-4 text-right">
           <button
             onClick={onClose}

--- a/index.css
+++ b/index.css
@@ -16,6 +16,14 @@
   padding: 0;
   border: none;
   background: transparent;
+  z-index: 10;
+  color: #dc2626;
+  font-weight: 700;
+  text-decoration: underline;
+}
+
+.add-slot-btn:hover {
+  color: #b91c1c;
 }
 
 .add-slot-btn:focus {


### PR DESCRIPTION
## Summary
- style calendar '+' button at top of day cells
- replace textareas with new `InfoEditor` rich text component
- include editor in `InfoModal`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856925ad1c0832680ecb80b7911a19a