### PR TITLE
Replace plus icon with clickable day number

### DIFF
--- a/CalendarPage.tsx
+++ b/CalendarPage.tsx
@@ -26,15 +26,14 @@ export function CalendarPage() {
         dayCellContent={(arg) => {
           const dateStr = arg.date.toISOString().split('T')[0];
           return (
-            <div className="day-cell h-full">
+            <div className="h-full">
               <button
                 type="button"
                 onClick={() => setCreatingDate(dateStr)}
-                className="add-slot-btn flex items-center justify-center text-xs hover:opacity-80"
+                className="p-1 rounded hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-accent"
               >
-                +
+                {arg.dayNumberText}
               </button>
-              <span>{arg.dayNumberText}</span>
             </div>
           );
         }}

--- a/index.css
+++ b/index.css
@@ -1,32 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-.day-cell {
-  position: relative;
-}
-
-.add-slot-btn {
-  position: absolute;
-  top: 4px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  z-index: 10;
-  color: #dc2626;
-  font-weight: 700;
-  text-decoration: underline;
-}
-
-.add-slot-btn:hover {
-  color: #b91c1c;
-}
-
-.add-slot-btn:focus {
-  outline: none;
-  box-shadow: none;
-}


### PR DESCRIPTION
## Summary
- remove `+` slot button from days
- use the day number itself as a button to open the create modal
- clean up styles no longer used

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856940ce4dc8326a8e08be9e6803bfe