### PR TITLE
Add style toolbar to Info editor

### DIFF
--- a/InfoEditor.tsx
+++ b/InfoEditor.tsx
@@ -48,24 +48,75 @@ export function InfoEditor({ value, onChange, maxLength = 3000 }: InfoEditorProp
 
   return (
     <div className="border border-gray-300 rounded-lg">
-      <div className="flex items-center space-x-2 p-2 border-b">
+      <div className="flex flex-wrap items-center gap-2 p-2 border-b text-xs">
+        <span className="text-gray-500 mr-1">Style de texte :</span>
         <select
-          className="border rounded px-1 text-xs"
+          className="border rounded px-1"
+          onChange={(e) => exec('fontName', e.target.value)}
+        >
+          {['Calibri', 'Arial', 'Times New Roman', 'Courier New'].map((f) => (
+            <option key={f} value={f} style={{ fontFamily: f }}>
+              {f}
+            </option>
+          ))}
+        </select>
+        <select
+          className="border rounded px-1"
           defaultValue="3"
           onChange={(e) => exec('fontSize', e.target.value)}
         >
-          <option value="2">Petit</option>
-          <option value="3">Normal</option>
-          <option value="5">Grand</option>
+          <option value="1">Petit</option>
+          <option value="2">11</option>
+          <option value="3">13</option>
+          <option value="4">16</option>
+          <option value="5">20</option>
+          <option value="6">24</option>
         </select>
         <button
           type="button"
+          onClick={() => exec('bold')}
+          className="font-bold px-1 border rounded"
+          aria-label="Gras"
+        >
+          B
+        </button>
+        <button
+          type="button"
+          onClick={() => exec('italic')}
+          className="italic px-1 border rounded"
+          aria-label="Italique"
+        >
+          I
+        </button>
+        <button
+          type="button"
           onClick={() => exec('underline')}
-          className="text-sm font-bold px-1 border rounded"
+          className="underline px-1 border rounded"
+          aria-label="Souligner"
         >
           U
         </button>
-        <div className="flex space-x-1">
+        <button
+          type="button"
+          onClick={() => exec('strikeThrough')}
+          className="line-through px-1 border rounded"
+          aria-label="Barré"
+        >
+          S
+        </button>
+        <div className="flex items-center space-x-1">
+          {['#ffffff', '#fef08a', '#bae6fd', '#bbf7d0'].map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => exec('hiliteColor', c)}
+              style={{ backgroundColor: c }}
+              className="w-4 h-4 rounded border"
+              aria-label={`Surlignage ${c}`}
+            />
+          ))}
+        </div>
+        <div className="flex items-center space-x-1">
           {['#000000', '#dc2626', '#2563eb', '#16a34a'].map((c) => (
             <button
               key={c}
@@ -73,6 +124,7 @@ export function InfoEditor({ value, onChange, maxLength = 3000 }: InfoEditorProp
               onClick={() => exec('foreColor', c)}
               style={{ backgroundColor: c }}
               className="w-4 h-4 rounded border"
+              aria-label={`Couleur ${c}`}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- add font, size and style toolbar in InfoEditor for IdeaBoard

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856971e6e988326890a605fff7aefe6