### PR TITLE
Selective invoice printing and interactive notifications

### DIFF
--- a/Header.tsx
+++ b/Header.tsx
@@ -27,6 +27,74 @@ export function Header() {
           </button>
           <Music className="w-6 h-6 text-primary" />
           <span className="font-bold text-dark dark:text-gray-100">CalZik</span>
+          <nav className="hidden md:flex ml-6 space-x-4 font-semibold">
+            <button
+              onClick={() => dispatch({ type: 'SET_TAB', payload: 'dashboard' })}
+              className={`hover:text-primary ${state.currentTab === 'dashboard' ? 'text-primary' : ''}`}
+            >
+              Tableau de bord
+            </button>
+            <button
+              onClick={() => dispatch({ type: 'SET_TAB', payload: 'calendar' })}
+              className={`hover:text-primary ${state.currentTab === 'calendar' ? 'text-primary' : ''}`}
+            >
+              Calendrier
+            </button>
+            <div className="relative">
+              <button
+                onClick={() => setShowResources(s => !s)}
+                className={`hover:text-primary ${
+                  state.currentTab === 'documents' || state.currentTab === 'ideas'
+                    ? 'text-primary'
+                    : ''
+                }`}
+              >
+                Ressources &#9662;
+              </button>
+              {showResources && (
+                <div className="absolute left-0 mt-2 w-40 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-2 space-y-1 z-30">
+                  <button
+                    className="block w-full text-left px-2 py-1 hover:bg-primary/5 rounded"
+                    onClick={() => {
+                      dispatch({ type: 'SET_TAB', payload: 'documents' });
+                      setShowResources(false);
+                    }}
+                  >
+                    Stockage de fichier
+                  </button>
+                  <button
+                    className="block w-full text-left px-2 py-1 hover:bg-primary/5 rounded"
+                    onClick={() => {
+                      dispatch({ type: 'SET_TAB', payload: 'ideas' });
+                      setShowResources(false);
+                    }}
+                  >
+                    Pense-Bête
+                  </button>
+                </div>
+              )}
+            </div>
+            <button
+              onClick={() => dispatch({ type: 'SET_TAB', payload: 'concerts' })}
+              className={`hover:text-primary ${state.currentTab === 'concerts' ? 'text-primary' : ''}`}
+            >
+              Concerts
+            </button>
+            <button
+              onClick={() => dispatch({ type: 'SET_TAB', payload: 'contacts' })}
+              className={`hover:text-primary ${state.currentTab === 'contacts' ? 'text-primary' : ''}`}
+            >
+              Contacts
+            </button>
+            {state.currentUser?.role === 'leader' && (
+              <button
+                onClick={() => dispatch({ type: 'SET_TAB', payload: 'admin' })}
+                className={`hover:text-primary ${state.currentTab === 'admin' ? 'text-primary' : ''}`}
+              >
+                Administration
+              </button>
+            )}
+          </nav>
         </div>
         <div className="flex items-center space-x-2 relative">
           <Link
@@ -57,74 +125,6 @@ export function Header() {
           </button>
         </div>
       </div>
-      <nav className="hidden md:flex space-x-4 px-4 pb-2">
-        <button
-          onClick={() => dispatch({ type: 'SET_TAB', payload: 'dashboard' })}
-          className={`hover:text-primary ${state.currentTab === 'dashboard' ? 'text-primary font-semibold' : ''}`}
-        >
-          Tableau de bord
-        </button>
-        <button
-          onClick={() => dispatch({ type: 'SET_TAB', payload: 'calendar' })}
-          className={`hover:text-primary ${state.currentTab === 'calendar' ? 'text-primary font-semibold' : ''}`}
-        >
-          Calendrier
-        </button>
-        <div className="relative">
-          <button
-            onClick={() => setShowResources(s => !s)}
-            className={`hover:text-primary ${
-              state.currentTab === 'documents' || state.currentTab === 'ideas'
-                ? 'text-primary font-semibold'
-                : ''
-            }`}
-          >
-            Ressources &#9662;
-          </button>
-          {showResources && (
-            <div className="absolute left-0 mt-2 w-40 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-2 space-y-1 z-30">
-              <button
-                className="block w-full text-left px-2 py-1 hover:bg-primary/5 rounded"
-                onClick={() => {
-                  dispatch({ type: 'SET_TAB', payload: 'documents' });
-                  setShowResources(false);
-                }}
-              >
-                Stockage de fichier
-              </button>
-              <button
-                className="block w-full text-left px-2 py-1 hover:bg-primary/5 rounded"
-                onClick={() => {
-                  dispatch({ type: 'SET_TAB', payload: 'ideas' });
-                  setShowResources(false);
-                }}
-              >
-                Pense-Bête
-              </button>
-            </div>
-          )}
-        </div>
-        <button
-          onClick={() => dispatch({ type: 'SET_TAB', payload: 'concerts' })}
-          className={`hover:text-primary ${state.currentTab === 'concerts' ? 'text-primary font-semibold' : ''}`}
-        >
-          Concerts
-        </button>
-        <button
-          onClick={() => dispatch({ type: 'SET_TAB', payload: 'contacts' })}
-          className={`hover:text-primary ${state.currentTab === 'contacts' ? 'text-primary font-semibold' : ''}`}
-        >
-          Contacts
-        </button>
-        {state.currentUser?.role === 'leader' && (
-          <button
-            onClick={() => dispatch({ type: 'SET_TAB', payload: 'admin' })}
-            className={`hover:text-primary ${state.currentTab === 'admin' ? 'text-primary font-semibold' : ''}`}
-          >
-            Administration
-          </button>
-        )}
-      </nav>
       <NavMenu open={open} onClose={() => setOpen(false)} />
     </header>
   );

--- a/InvoicePage.tsx
+++ b/InvoicePage.tsx
@@ -26,7 +26,7 @@ export function InvoicePage() {
           </thead>
           <tbody>
             {unpaid.map(inv => (
-              <tr key={inv.id} className="border-t">
+              <tr key={inv.id} id={`inv-${inv.id}`} className="border-t">
                 <td className="p-2">{inv.number}</td>
                 <td className="p-2">{inv.clientName}</td>
                 <td className="p-2">{inv.amountTTC} €</td>
@@ -67,7 +67,7 @@ export function InvoicePage() {
           </thead>
           <tbody>
             {paid.map(inv => (
-              <tr key={inv.id} className="border-t">
+              <tr key={inv.id} id={`inv-${inv.id}`} className="border-t">
                 <td className="p-2">{inv.number}</td>
                 <td className="p-2">{inv.clientName}</td>
                 <td className="p-2">{inv.amountTTC} €</td>

--- a/InvoiceWizard.tsx
+++ b/InvoiceWizard.tsx
@@ -139,13 +139,79 @@ export function InvoiceWizard() {
         </div>
       )}
       {step === 5 && (
-        <div className="space-y-2">
+        <div className="space-y-4">
           <h2 className="font-semibold">Aperçu</h2>
-          <div>Prestataire: {form.providerName}</div>
-          <div>Client: {form.clientName}</div>
-          <div>Prestation: {form.serviceTitle} - {form.location}</div>
-          <div>Montant TTC: {form.amountTTC} €</div>
-          <button type="button" onClick={() => window.print()} className="mt-2 bg-primary text-white px-4 py-2 rounded">Imprimer</button>
+          <div id="invoice-printable" className="p-4 bg-white border rounded shadow space-y-4">
+            <div className="flex justify-between items-start">
+              <div className="text-2xl font-bold">CalZik</div>
+              <div className="text-right text-sm space-y-1">
+                <div>Date : {form.serviceDate}</div>
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-6 text-sm">
+              <div>
+                <h3 className="font-semibold mb-1">Prestataire</h3>
+                <div>{form.providerName}</div>
+                <div>{form.providerAddress}</div>
+                {form.providerSiret && <div>SIRET : {form.providerSiret}</div>}
+                {form.providerVat && <div>TVA : {form.providerVat}</div>}
+              </div>
+              <div>
+                <h3 className="font-semibold mb-1">Client</h3>
+                <div>{form.clientName}</div>
+                <div>{form.clientAddress}</div>
+                {form.clientSiret && <div>SIRET : {form.clientSiret}</div>}
+                {form.clientVat && <div>TVA : {form.clientVat}</div>}
+              </div>
+            </div>
+            <table className="w-full text-sm border mt-4">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="p-2 text-left">Prestation</th>
+                  <th className="p-2 text-right">Montant HT</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="p-2">
+                    {form.serviceTitle} - {form.location}
+                  </td>
+                  <td className="p-2 text-right">{form.amountHT} €</td>
+                </tr>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td className="p-2 text-right font-semibold">Sous-total</td>
+                  <td className="p-2 text-right">{form.amountHT} €</td>
+                </tr>
+                <tr>
+                  <td className="p-2 text-right">TVA {form.vatRate}%</td>
+                  <td className="p-2 text-right">
+                    {(
+                      parseFloat(form.amountTTC || '0') -
+                      parseFloat(form.amountHT || '0')
+                    ).toFixed(2)}{' '}
+                    €
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-2 text-right font-bold">Total TTC</td>
+                  <td className="p-2 text-right font-bold">{form.amountTTC} €</td>
+                </tr>
+              </tfoot>
+            </table>
+            <div className="text-xs mt-4">
+              Conditions de paiement : règlement à réception.<br />
+              Mentions légales : association loi 1901.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => window.print()}
+            className="mt-2 bg-primary text-white px-4 py-2 rounded"
+          >
+            Imprimer
+          </button>
         </div>
       )}
       <div className="flex justify-between pt-4">

--- a/index.css
+++ b/index.css
@@ -2,11 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+#invoice-printable {
+  max-width: 210mm;
+  margin: 0 auto;
+}
+
 @media print {
-  #invoice-preview {
-    box-shadow: none;
-    border: none;
+  body * {
+    visibility: hidden;
+  }
+  #invoice-printable, #invoice-printable * {
+    visibility: visible;
+  }
+  #invoice-printable {
+    position: absolute;
+    left: 0;
+    top: 0;
     width: 210mm;
-    margin: 0 auto;
   }
 }

--- a/useInvoices.tsx
+++ b/useInvoices.tsx
@@ -53,7 +53,12 @@ export function InvoicesProvider({ children }: { children: ReactNode }) {
       const due = new Date(inv.serviceDate);
       due.setDate(due.getDate() + 30);
       if (!inv.isPaid && new Date() > due) {
-        add({ id: notifId, message: `Facture ${inv.number} en retard`, date: new Date().toISOString() });
+        add({
+          id: notifId,
+          message: `Facture ${inv.number} en retard`,
+          date: new Date().toISOString(),
+          link: `/invoice#inv-${inv.id}`,
+        });
       } else {
         remove(notifId);
       }
@@ -75,7 +80,12 @@ export function InvoicesProvider({ children }: { children: ReactNode }) {
     const due = new Date(invoice.serviceDate);
     due.setDate(due.getDate() + 30);
     if (new Date() > due) {
-      add({ id: `invoice-${invoice.id}`, message: `Facture ${invoice.number} en retard`, date: new Date().toISOString() });
+      add({
+        id: `invoice-${invoice.id}`,
+        message: `Facture ${invoice.number} en retard`,
+        date: new Date().toISOString(),
+        link: `/invoice#inv-${invoice.id}`,
+      });
     }
     return invoice;
   };

--- a/useNotifications.tsx
+++ b/useNotifications.tsx
@@ -1,9 +1,11 @@
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 
 export interface Notification {
   id: string;
   message: string;
   date: string;
+  link?: string;
   read?: boolean;
 }
 
@@ -12,6 +14,7 @@ interface NotificationsCtx {
   add: (notification: Notification) => void;
   remove: (id: string) => void;
   markAllRead: () => void;
+  markRead: (id: string) => void;
 }
 
 const NotificationsContext = createContext<NotificationsCtx | undefined>(undefined);
@@ -52,8 +55,14 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     setNotifications(prev => prev.map(n => ({ ...n, read: true })));
   };
 
+  const markRead = (id: string) => {
+    setNotifications(prev =>
+      prev.map(n => (n.id === id ? { ...n, read: true } : n))
+    );
+  };
+
   return (
-    <NotificationsContext.Provider value={{ notifications, add, remove, markAllRead }}>
+    <NotificationsContext.Provider value={{ notifications, add, remove, markAllRead, markRead }}>
       {children}
     </NotificationsContext.Provider>
   );
@@ -66,15 +75,35 @@ export function useNotifications() {
 }
 
 export function NotificationList() {
-  const { notifications, remove } = useNotifications();
+  const { notifications, remove, markRead } = useNotifications();
   if (!notifications.length) return null;
 
   return (
     <div className="fixed bottom-4 right-4 space-y-2 z-50">
       {notifications.map(n => (
-        <div key={n.id} className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 p-3 rounded shadow flex items-start justify-between space-x-4">
-          <span>{n.message}</span>
-          <button onClick={() => remove(n.id)} className="text-sm text-primary">Fermer</button>
+        <div
+          key={n.id}
+          className={`border p-3 rounded shadow flex items-start justify-between space-x-4 ${
+            n.read ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700' : 'bg-blue-50 border-blue-200'
+          }`}
+        >
+          {n.link ? (
+            <Link
+              to={n.link}
+              onClick={() => markRead(n.id)}
+              className="flex-1 hover:underline"
+            >
+              {n.message}
+            </Link>
+          ) : (
+            <span className="flex-1">{n.message}</span>
+          )}
+          <button
+            onClick={() => remove(n.id)}
+            className="text-sm text-primary"
+          >
+            Fermer
+          </button>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- add printable invoice zone and update print stylesheet
- style invoice preview with logo, totals, and legal text
- align header nav on a single line with bolder links
- mark notifications read on click and allow navigation
- link invoice notifications to corresponding table rows

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68599bdf6cdc8326973f7c5ede26dcce