### PR TITLE
Fix nav ordering and logo link

### DIFF
--- a/Header.tsx
+++ b/Header.tsx
@@ -26,9 +26,12 @@ export function Header() {
           >
             &#9776;
           </button>
-          <Music className="w-6 h-6 text-primary" />
-          <Link to="/" className="font-bold text-dark dark:text-gray-100">
-            CalZik
+          <Link
+            to="/"
+            className="flex items-center space-x-2 font-bold text-dark dark:text-gray-100"
+          >
+            <Music className="w-6 h-6 text-primary" />
+            <span>CalZik</span>
           </Link>
           <nav className="hidden md:flex ml-6 space-x-4 font-semibold">
             <button
@@ -43,6 +46,12 @@ export function Header() {
             >
               Contacts
             </button>
+            <button
+              onClick={() => dispatch({ type: 'SET_TAB', payload: 'concerts' })}
+              className={`hover:text-primary ${state.currentTab === 'concerts' ? 'text-primary' : ''}`}
+            >
+              Concerts
+            </button>
             <div className="relative">
               <button
                 onClick={() => setShowResources(s => !s)}
@@ -54,14 +63,11 @@ export function Header() {
               >
                 Ressources &#9662;
               </button>
-              <ResourcesMenu open={showResources} onClose={() => setShowResources(false)} />
+              <ResourcesMenu
+                open={showResources}
+                onClose={() => setShowResources(false)}
+              />
             </div>
-            <button
-              onClick={() => dispatch({ type: 'SET_TAB', payload: 'concerts' })}
-              className={`hover:text-primary ${state.currentTab === 'concerts' ? 'text-primary' : ''}`}
-            >
-              Concerts
-            </button>
             {state.currentUser?.role === 'leader' && (
               <button
                 onClick={() => dispatch({ type: 'SET_TAB', payload: 'admin' })}

--- a/NavMenu.tsx
+++ b/NavMenu.tsx
@@ -16,11 +16,15 @@ export function NavMenu({ open, onClose }: Props) {
   const menuItems = [
     { id: 'calendar' as const, label: 'Calendrier' },
     { id: 'contacts' as const, label: 'Contacts' },
+    { id: 'concerts' as const, label: 'Concerts' },
     { id: 'documents' as const, label: 'Stockage de fichier' },
     { id: 'ideas' as const, label: 'Pense-Bête' },
-    ...(currentUser?.role === 'leader' ? [{ id: 'invoice' as const, label: 'Factures' }] : []),
-    { id: 'concerts' as const, label: 'Concerts' },
-    ...(currentUser?.role === 'leader' ? [{ id: 'admin' as const, label: 'Administration' }] : []),
+    ...(currentUser?.role === 'leader'
+      ? [{ id: 'invoice' as const, label: 'Factures' }]
+      : []),
+    ...(currentUser?.role === 'leader'
+      ? [{ id: 'admin' as const, label: 'Administration' }]
+      : []),
   ];
 
   if (!open) return null;


### PR DESCRIPTION
## Summary
- make logo and icon a single link to `/`
- show Concerts before Ressources
- reorder NavMenu items to match header

## Testing
- `npm install`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6859b34c4cf0832695b55048fe909b0e