### PR TITLE
Add new HomePage and update routing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,9 +7,10 @@ import { LoginForm } from './LoginForm';
 import { Header } from './Header';
 import { Role } from './roles';
 import { NotificationsPage } from './NotificationsPage';
+import HomePage from './HomePage';
 const Dashboard = React.lazy(() => import('./Dashboard').then(m => ({ default: m.Dashboard })));
 const AvailabilityCalendar = React.lazy(() => import('./AvailabilityCalendar').then(m => ({ default: m.AvailabilityCalendar })));
-import { Routes, Route, useLocation } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 const CalendarPage = React.lazy(() => import('./CalendarPage').then(m => ({ default: m.CalendarPage }))); 
 const EventsPage = React.lazy(() => import('./EventsPage').then(m => ({ default: m.EventsPage })));
 const InvoicePage = React.lazy(() => import('./InvoicePage').then(m => ({ default: m.InvoicePage })));
@@ -36,7 +37,7 @@ function AppContent() {
   useEffect(() => {
     if (location.pathname === '/ressources/factures') {
       dispatch({ type: 'SET_TAB', payload: 'invoice' });
-    } else if (location.pathname === '/') {
+    } else if (location.pathname === '/dashboard') {
       dispatch({ type: 'SET_TAB', payload: 'dashboard' });
     }
   }, [location.pathname, dispatch]);
@@ -90,11 +91,12 @@ function App() {
         <InvoicesProvider>
           <AppProvider>
             <Routes>
+              <Route path="/" element={<HomePage />} />
+              <Route path="/dashboard" element={<AppContent />} />
               <Route path="/concerts/:eventId" element={<AppContent />} />
               <Route path="/ressources/factures" element={<AppContent />} />
               <Route path="/notifications" element={<NotificationsPage />} />
-              <Route path="/" element={<AppContent />} />
-              <Route path="*" element={<AppContent />} />
+              <Route path="*" element={<Navigate to="/" />} />
             </Routes>
             <NotificationList />
           </AppProvider>

--- a/HOME_REPORT.md
+++ b/HOME_REPORT.md
@@ -1,0 +1,12 @@
+# Rapport Home Page
+
+## Structure
+- **Hero plein écran** avec texte "Welcome to CalZik", slogan et bouton vers le calendrier.
+- **Section Fonctionnalités clés** composée de 3 cartes néon : Planification, Calendrier et Facturation.
+- **Bouton Commencer** renvoyant vers la page Calendrier.
+- Animations Framer Motion : apparition en fondu/slide sur la hero et halo sur les cartes au survol.
+
+## Tests manuels
+1. Depuis l'en-tête, cliquer sur **CalZik** ouvre la nouvelle HomePage.
+2. Cliquer sur **Découvrir le calendrier** ou **Commencer** navigue vers `/calendar`.
+3. Vérifier l'animation d'entrée de la section hero et le glow des cartes sur desktop et mobile.

--- a/HomePage.tsx
+++ b/HomePage.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { Calendar, ListChecks, CreditCard } from 'lucide-react';
+
+export function HomePage() {
+  const features = [
+    {
+      icon: Calendar,
+      title: 'Planification',
+      desc: "Organisez facilement vos répétitions et concerts avec un agenda partagé.",
+    },
+    {
+      icon: ListChecks,
+      title: 'Calendrier',
+      desc: "Suivez tous les événements importants de votre groupe en un coup d'œil.",
+    },
+    {
+      icon: CreditCard,
+      title: 'Facturation',
+      desc: "Générez vos factures et suivez les paiements sans effort.",
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <motion.section
+        initial={{ opacity: 0, y: 40 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+        className="flex flex-col items-center justify-center text-center p-8 h-screen bg-[radial-gradient(circle_at_center,_var(--tw-gradient-stops))] from-gray-800 via-gray-900 to-black"
+      >
+        <h1 className="text-5xl md:text-7xl font-extrabold mb-4 font-heading">
+          Welcome to CalZik
+        </h1>
+        <p className="text-xl md:text-2xl mb-8 max-w-2xl">
+          Gérez vos concerts, disponibilités et factures au même endroit.
+        </p>
+        <Link
+          to="/calendar"
+          className="px-6 py-3 rounded-full bg-primary hover:bg-primary/90 transition-colors"
+        >
+          Découvrir le calendrier
+        </Link>
+      </motion.section>
+
+      <section className="py-16 bg-gray-950">
+        <div className="max-w-5xl mx-auto px-4 grid md:grid-cols-3 gap-8 text-center">
+          {features.map(({ icon: Icon, title, desc }) => (
+            <motion.div
+              key={title}
+              whileHover={{ boxShadow: '0 0 15px rgba(255,255,255,0.6)' }}
+              className="p-6 bg-gray-800 rounded-xl space-y-4"
+            >
+              <Icon className="w-10 h-10 mx-auto text-accent" />
+              <h3 className="text-xl font-semibold">{title}</h3>
+              <p className="text-gray-300 text-sm">{desc}</p>
+            </motion.div>
+          ))}
+        </div>
+        <div className="mt-12 text-center">
+          <Link
+            to="/calendar"
+            className="px-6 py-3 rounded-full bg-accent hover:bg-accent/90 transition-colors"
+          >
+            Commencer
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default HomePage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@fullcalendar/core": "^6.1.17",
         "@fullcalendar/daygrid": "^6.1.17",
         "@fullcalendar/react": "^6.1.17",
+        "framer-motion": "^12.19.1",
         "localforage": "^1.10.0",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
@@ -4902,6 +4903,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.19.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.19.1.tgz",
+      "integrity": "sha512-nq9hwWAEKf4gzprbOZzKugLV5OVKF7zrNDY6UOVu+4D3ZgIkg8L9Jy6AMrpBM06fhbKJ6LEG6UY5+t7Eq6wNlg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.19.0",
+        "motion-utils": "^12.19.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -6312,6 +6340,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.19.0.tgz",
+      "integrity": "sha512-m96uqq8VbwxFLU0mtmlsIVe8NGGSdpBvBSHbnnOJQxniPaabvVdGgxSamhuDwBsRhwX7xPxdICgVJlOpzn/5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.19.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8242,6 +8285,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@fullcalendar/core": "^6.1.17",
     "@fullcalendar/daygrid": "^6.1.17",
     "@fullcalendar/react": "^6.1.17",
+    "framer-motion": "^12.19.1",
     "localforage": "^1.10.0",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary
- create `HomePage` with hero and features sections
- link logo to home
- add framer-motion dependency
- update routes so `/` loads `HomePage` and former dashboard is under `/dashboard`
- document home page features and manual tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6859c0fa961c83269619451ca3ec16f0