### PR TITLE
Implement dark neon theme

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -71,7 +71,7 @@ function AppContent() {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 dark:bg-gray-900 dark:text-gray-100">
+    <div className="min-h-screen bg-light dark:bg-dark dark:text-light">
       <Header />
       <main className="pb-20 md:pb-0">
         <React.Suspense fallback={<div className="p-4">Chargement...</div>}>

--- a/Dashboard.tsx
+++ b/Dashboard.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Calendar, Music, Users, TrendingUp, Clock, MapPin } from 'lucide-react';
+import { NeonCard } from './NeonCard';
+import { NeonBadge } from './NeonBadge';
 import { useApp } from './AppContext';
 
 export function Dashboard() {
@@ -39,7 +41,7 @@ export function Dashboard() {
 
       {/* Stats Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-        <div className="bg-white rounded-xl p-3 border border-gray-100">
+        <NeonCard>
           <div className="flex items-center justify-between mb-4">
             <div className="p-3 bg-primary/10 rounded-lg">
               <Users className="w-6 h-6 text-primary" />
@@ -47,9 +49,9 @@ export function Dashboard() {
             <span className="text-2xl font-bold text-dark">{totalMembers}</span>
           </div>
           <h3 className="text-sm font-medium text-gray-600">Musiciens actifs</h3>
-        </div>
+        </NeonCard>
 
-        <div className="bg-white rounded-xl p-3 border border-gray-100">
+        <NeonCard>
           <div className="flex items-center justify-between mb-4">
             <div className="p-3 bg-accent/20 rounded-lg">
               <Music className="w-6 h-6 text-accent" />
@@ -57,9 +59,9 @@ export function Dashboard() {
             <span className="text-2xl font-bold text-dark">{confirmedConcerts}</span>
           </div>
           <h3 className="text-sm font-medium text-gray-600">Concerts confirmés</h3>
-        </div>
+        </NeonCard>
 
-        <div className="bg-white rounded-xl p-3 border border-gray-100">
+        <NeonCard>
           <div className="flex items-center justify-between mb-4">
             <div className="p-3 bg-accent/20 rounded-lg">
               <TrendingUp className="w-6 h-6 text-accent" />
@@ -67,9 +69,9 @@ export function Dashboard() {
             <span className="text-2xl font-bold text-dark">{getAvailabilityStats()}%</span>
           </div>
           <h3 className="text-sm font-medium text-gray-600">Disponibilité</h3>
-        </div>
+        </NeonCard>
 
-        <div className="bg-white rounded-xl p-3 border border-gray-100">
+        <NeonCard>
           <div className="flex items-center justify-between mb-4">
             <div className="p-3 bg-accent/20 rounded-lg">
               <Calendar className="w-6 h-6 text-accent" />
@@ -77,13 +79,13 @@ export function Dashboard() {
             <span className="text-2xl font-bold text-dark">{upcomingConcerts.length}</span>
           </div>
           <h3 className="text-sm font-medium text-gray-600">Prochains événements</h3>
-        </div>
+        </NeonCard>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Next Rehearsal */}
         {nextRehearsal && (
-          <div className="bg-white rounded-xl p-3 border border-gray-100">
+          <NeonCard>
             <h3 className="text-xl font-semibold text-dark mb-4 flex items-center">
               <Clock className="w-5 h-5 mr-2 text-primary" />
               Prochaine répétition
@@ -110,11 +112,11 @@ export function Dashboard() {
                 </div>
               </div>
             </div>
-          </div>
+          </NeonCard>
         )}
 
         {/* Upcoming Concerts */}
-        <div className="bg-white rounded-xl p-3 border border-gray-100">
+        <NeonCard>
           <h3 className="text-xl font-semibold text-dark mb-4 flex items-center">
             <Music className="w-5 h-5 mr-2 text-accent" />
             Prochains concerts
@@ -125,16 +127,22 @@ export function Dashboard() {
                 <div key={concert.id} className="border border-gray-200 rounded-lg p-3 transition-colors">
                   <div className="flex items-center justify-between mb-2">
                     <h4 className="font-semibold text-dark">{concert.title}</h4>
-                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-                      concert.status === 'confirmed'
-                        ? 'bg-accent/20 text-accent'
+                    <NeonBadge
+                      className="ml-2"
+                      color={
+                        concert.status === 'confirmed'
+                          ? 'accent'
+                          : concert.status === 'pending'
+                          ? 'accent'
+                          : 'primary'
+                      }
+                    >
+                      {concert.status === 'confirmed'
+                        ? 'Confirmé'
                         : concert.status === 'pending'
-                        ? 'bg-accent/20 text-accent'
-                        : 'bg-primary/20 text-primary'
-                    }`}>
-                      {concert.status === 'confirmed' ? 'Confirmé' : 
-                       concert.status === 'pending' ? 'En attente' : 'Annulé'}
-                    </span>
+                        ? 'En attente'
+                        : 'Annulé'}
+                    </NeonBadge>
                   </div>
                   <div className="text-sm text-gray-600 space-y-1">
                     <div className="flex items-center">
@@ -154,7 +162,7 @@ export function Dashboard() {
               </p>
             )}
           </div>
-        </div>
+        </NeonCard>
       </div>
     </div>
   );

--- a/EventsPage.tsx
+++ b/EventsPage.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Calendar, MapPin, List as ListIcon, LayoutGrid } from 'lucide-react';
+import { NeonButton } from './NeonButton';
+import { NeonCard } from './NeonCard';
+import { NeonBadge } from './NeonBadge';
 import { useEvents, Event as EventType } from './useEvents';
 import { useNavigate, useParams } from 'react-router-dom';
 import { EventFormModal } from './EventFormModal';
@@ -31,21 +34,14 @@ export function EventsPage() {
   };
 
   const getTypeBadge = (type: EventType['type']) => {
-    const styles = {
-      gig: 'bg-primary/10 text-primary',
-      rehearsal: 'bg-accent/20 text-accent',
-    };
-
     const labels = {
       gig: 'Concert',
       rehearsal: 'Répétition',
     };
 
-    return (
-      <span className={`px-2 py-1 rounded-full text-xs font-medium ${styles[type]}`}>
-        {labels[type]}
-      </span>
-    );
+    const color = type === 'gig' ? 'primary' : 'accent';
+
+    return <NeonBadge color={color}>{labels[type]}</NeonBadge>;
   };
 
   const sortedEvents = [...events].sort((a, b) =>
@@ -76,16 +72,16 @@ export function EventsPage() {
           >
             <LayoutGrid className="w-5 h-5" />
           </button>
-          <button
+          <NeonButton
             onClick={() => {
               setEditingEvent(null);
               setShowModal(true);
             }}
-            className="bg-primary text-white px-4 py-2 rounded-lg font-medium hover:bg-primary/90 transition-colors flex items-center space-x-2 focus:outline-none focus:ring-2 focus:ring-accent"
+            className="flex items-center space-x-2"
           >
             <Plus className="w-5 h-5" />
             <span>Nouvel événement</span>
-          </button>
+          </NeonButton>
         </div>
       </div>
 
@@ -96,11 +92,7 @@ export function EventsPage() {
             const isPast = new Date(event.date) < new Date();
             return (
               <div style={style} className="p-2">
-                <div
-                  className={`bg-white rounded-xl p-3 border border-gray-100 hover:shadow-lg transition-shadow ${
-                    isPast ? 'opacity-75' : ''
-                  }`}
-                >
+                <NeonCard className={`${isPast ? 'opacity-75' : ''}`}>
                   <h3 className="text-lg font-semibold text-dark mb-2">{event.title}</h3>
                   <div className="flex items-center space-x-2 mb-4">{getTypeBadge(event.type)}</div>
                   <div className="space-y-3 text-sm text-gray-600">
@@ -119,7 +111,7 @@ export function EventsPage() {
                       {event.location}
                     </div>
                   </div>
-                </div>
+                </NeonCard>
               </div>
             );
           }}
@@ -129,7 +121,7 @@ export function EventsPage() {
           {sortedEvents.map(event => {
             const isPast = new Date(event.date) < new Date();
             return (
-              <div key={event.id} className={`concert-grid-card bg-white rounded-xl p-3 border border-gray-100 hover:shadow-lg transition-shadow ${isPast ? 'opacity-75' : ''}`}> 
+              <NeonCard key={event.id} className={`concert-grid-card ${isPast ? 'opacity-75' : ''}`}>
                 <h3 className="text-lg font-semibold text-dark mb-2">{event.title}</h3>
                 <div className="flex items-center space-x-2 mb-4">{getTypeBadge(event.type)}</div>
                 <div className="space-y-3 text-sm text-gray-600">
@@ -148,7 +140,7 @@ export function EventsPage() {
                     {event.location}
                   </div>
                 </div>
-              </div>
+              </NeonCard>
             );
           })}
         </div>

--- a/NeonBadge.tsx
+++ b/NeonBadge.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface NeonBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  color?: 'primary' | 'accent' | 'success';
+}
+
+export const NeonBadge: React.FC<NeonBadgeProps> = ({
+  color = 'primary',
+  className = '',
+  ...props
+}) => {
+  const colors = {
+    primary: 'bg-primary/20 text-primary',
+    accent: 'bg-accent/20 text-accent',
+    success: 'bg-success/20 text-success',
+  };
+  return (
+    <span
+      className={`px-2 py-1 rounded-full text-xs font-semibold ${colors[color]} ${className}`}
+      {...props}
+    />
+  );
+};

--- a/NeonButton.tsx
+++ b/NeonButton.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface NeonButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const NeonButton: React.FC<NeonButtonProps> = ({ className = '', ...props }) => {
+  const base =
+    'px-4 py-2 rounded-lg font-medium text-white focus:outline-none focus:ring-2 focus:ring-accent transition';
+  const gradient =
+    'bg-gradient-to-r from-primary via-accent to-primary neon-gradient shadow-neon hover:opacity-90';
+  return <button className={`${base} ${gradient} ${className}`} {...props} />;
+};

--- a/NeonCard.tsx
+++ b/NeonCard.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+interface NeonCardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const NeonCard: React.FC<NeonCardProps> = ({ className = '', ...props }) => {
+  return (
+    <div
+      className={`bg-dark/60 border border-primary/50 rounded-xl p-4 shadow-neon backdrop-blur-md ${className}`}
+      {...props}
+    />
+  );
+};

--- a/index.css
+++ b/index.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  body {
+    @apply font-sans bg-light text-gray-800 dark:bg-dark dark:text-light;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-heading;
+  }
+}
+
 #invoice-printable {
   max-width: 210mm;
   margin: 0 auto;
@@ -44,4 +53,18 @@
 
 .logo-button:hover {
   transform: scale(1.05);
+}
+
+@keyframes gradient-x {
+  0%, 100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}
+
+.neon-gradient {
+  background-size: 200% 200%;
+  animation: gradient-x 4s ease-in-out infinite;
 }

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Space+Grotesk:wght@600;700&display=swap" rel="stylesheet" />
     <title>CalZik - Gestion des disponibilités musiciens</title>
   </head>
   <body>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,10 +5,18 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: '#0077B6',
-        accent: '#C04A00',
-        dark: '#2F2F2F',
+        primary: '#A855F7',
+        accent: '#06B6D4',
+        dark: '#0E0F13',
         success: '#22C55E',
+        light: '#E5E7EB',
+      },
+      fontFamily: {
+        heading: ['"Space Grotesk"', 'sans-serif'],
+        sans: ['Inter', 'sans-serif'],
+      },
+      boxShadow: {
+        neon: '0 0 15px rgba(168, 85, 247, 0.6)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add Inter and Space Grotesk fonts
- extend Tailwind palette and fonts for neon design
- add base styles and gradient animation
- create `NeonCard`, `NeonButton`, `NeonBadge`
- refactor Dashboard and Concert pages to use neon components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859bda10ea0832690091c371c032769