### PR TITLE
Fix calendar navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -92,6 +92,7 @@ function App() {
           <AppProvider>
             <Routes>
               <Route path="/" element={<HomePage />} />
+              <Route path="/calendar" element={<CalendarPage />} />
               <Route path="/dashboard" element={<AppContent />} />
               <Route path="/concerts/:eventId" element={<AppContent />} />
               <Route path="/ressources/factures" element={<AppContent />} />


### PR DESCRIPTION
## Summary
- add route `/calendar` to display CalendarPage

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6859c64f08f88326a262161ccbf5f9c6